### PR TITLE
Conditionally replace deprecated/removed C++98 std::random_shuffle by…

### DIFF
--- a/test/common_heap_tests.hpp
+++ b/test/common_heap_tests.hpp
@@ -18,6 +18,29 @@
 
 #include <boost/heap/heap_concepts.hpp>
 
+#ifdef BOOST_NO_CXX98_RANDOM_SHUFFLE
+#include <cstdlib>
+#include <iterator>
+
+template<class RandomIt>
+void random_shuffle(RandomIt first, RandomIt last)
+{
+    typedef typename std::iterator_traits<RandomIt>::difference_type difference_type;
+    difference_type n = last - first;
+    for (difference_type i = n-1; i > 0; --i) {
+        difference_type j = std::rand() % (i + 1);
+        if (j != i) {
+		   using std::swap;  
+           swap(first[i], first[j]);
+        }
+    }
+}
+
+#else
+	
+using std::random_shuffle;
+
+#endif
 
 typedef boost::default_constructible_archetype<
         boost::less_than_comparable_archetype<
@@ -132,7 +155,7 @@ void pri_queue_test_random_push(void)
         test_data data = make_test_data(i);
 
         test_data shuffled (data);
-        std::random_shuffle(shuffled.begin(), shuffled.end());
+        random_shuffle(shuffled.begin(), shuffled.end());
 
         fill_q(q, shuffled);
 
@@ -211,7 +234,7 @@ void pri_queue_test_swap(void)
         pri_queue q;
         test_data data = make_test_data(i);
         test_data shuffled (data);
-        std::random_shuffle(shuffled.begin(), shuffled.end());
+        random_shuffle(shuffled.begin(), shuffled.end());
         fill_q(q, shuffled);
 
         pri_queue r;
@@ -229,7 +252,7 @@ void pri_queue_test_iterators(void)
     for (int i = 0; i != test_size; ++i) {
         test_data data = make_test_data(test_size);
         test_data shuffled (data);
-        std::random_shuffle(shuffled.begin(), shuffled.end());
+        random_shuffle(shuffled.begin(), shuffled.end());
         pri_queue q;
         BOOST_REQUIRE(q.begin() == q.end());
         fill_q(q, shuffled);
@@ -258,7 +281,7 @@ void pri_queue_test_ordered_iterators(void)
     for (int i = 0; i != test_size; ++i) {
         test_data data = make_test_data(i);
         test_data shuffled (data);
-        std::random_shuffle(shuffled.begin(), shuffled.end());
+        random_shuffle(shuffled.begin(), shuffled.end());
         pri_queue q;
         BOOST_REQUIRE(q.ordered_begin() == q.ordered_end());
         fill_q(q, shuffled);

--- a/test/merge_heap_tests.hpp
+++ b/test/merge_heap_tests.hpp
@@ -11,7 +11,7 @@
 
 #define GENERATE_TEST_DATA(INDEX)                           \
     test_data data = make_test_data(test_size, 0, 1);       \
-    std::random_shuffle(data.begin(), data.end());          \
+    random_shuffle(data.begin(), data.end());               \
                                                             \
     test_data data_q (data.begin(), data.begin() + INDEX);  \
     test_data data_r (data.begin() + INDEX, data.end());    \

--- a/test/mutable_heap_tests.hpp
+++ b/test/mutable_heap_tests.hpp
@@ -82,7 +82,7 @@ void pri_queue_test_update_shuffled(void)
     PUSH_WITH_HANDLES(handles, q, data);
 
     test_data shuffled (data);
-    std::random_shuffle(shuffled.begin(), shuffled.end());
+    random_shuffle(shuffled.begin(), shuffled.end());
 
     for (int i = 0; i != test_size; ++i)
         q.update(handles[i], shuffled[i]);


### PR DESCRIPTION
… a drop-in implementation.

Signed-off-by: Daniela Engert <dani@ngrt.de>