### PR TITLE
Most members of std::allocate are deprecated in C++17

### DIFF
--- a/include/boost/heap/binomial_heap.hpp
+++ b/include/boost/heap/binomial_heap.hpp
@@ -56,7 +56,11 @@ struct make_binomial_heap_base
 
     typedef parent_pointing_heap_node<typename base_type::internal_type> node_type;
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     typedef typename allocator_argument::template rebind<node_type>::other allocator_type;
+#else
+    typedef typename std::allocator_traits<allocator_argument>::template rebind_alloc<node_type> allocator_type;
+#endif
 
     struct type:
         base_type,
@@ -157,8 +161,14 @@ private:
         typedef typename base_maker::allocator_type allocator_type;
         typedef typename base_maker::node_type node;
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         typedef typename allocator_type::pointer node_pointer;
         typedef typename allocator_type::const_pointer const_node_pointer;
+#else
+        typedef std::allocator_traits<allocator_type> allocator_traits;
+        typedef typename allocator_traits::pointer node_pointer;
+        typedef typename allocator_traits::const_pointer const_node_pointer;
+#endif
 
         typedef detail::node_handle<node_pointer, super_t, reference> handle_type;
 
@@ -199,6 +209,9 @@ public:
     typedef typename implementation_defined::difference_type difference_type;
     typedef typename implementation_defined::value_compare value_compare;
     typedef typename implementation_defined::allocator_type allocator_type;
+#ifndef BOOST_NO_CXX11_ALLOCATOR
+    typedef typename implementation_defined::allocator_traits allocator_traits;
+#endif
     typedef typename implementation_defined::reference reference;
     typedef typename implementation_defined::const_reference const_reference;
     typedef typename implementation_defined::pointer pointer;
@@ -303,7 +316,12 @@ public:
     /// \copydoc boost::heap::priority_queue::max_size
     size_type max_size(void) const
     {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         return allocator_type::max_size();
+#else
+        const allocator_type& alloc = *this;
+        return allocator_traits::max_size(alloc);
+#endif
     }
 
     /// \copydoc boost::heap::priority_queue::clear
@@ -346,9 +364,14 @@ public:
      * */
     handle_type push(value_type const & v)
     {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         node_pointer n = allocator_type::allocate(1);
         new(n) node_type(super_t::make_node(v));
-
+#else
+        allocator_type& alloc = *this;
+        node_pointer n = allocator_traits::allocate(alloc, 1);
+        allocator_traits::construct(alloc, n, super_t::make_node(v));
+#endif
         insert_node(trees.begin(), n);
 
         if (!top_element || super_t::operator()(top_element->value, n->value))
@@ -369,9 +392,14 @@ public:
     template <class... Args>
     handle_type emplace(Args&&... args)
     {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         node_pointer n = allocator_type::allocate(1);
         new(n) node_type(super_t::make_node(std::forward<Args>(args)...));
-
+#else
+        allocator_type& alloc = *this;
+        node_pointer n = allocator_traits::allocate(alloc, 1);
+        allocator_traits::construct(alloc, n, super_t::make_node(std::forward<Args>(args)...));
+#endif
         insert_node(trees.begin(), n);
 
         if (!top_element || super_t::operator()(top_element->value, n->value))
@@ -421,8 +449,14 @@ public:
         else
             update_top_element();
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         element->~node_type();
         allocator_type::deallocate(element, 1);
+#else
+        allocator_type& alloc = *this;
+        allocator_traits::destroy(alloc, element);
+        allocator_traits::deallocate(alloc, element, 1);
+#endif
         sanity_check();
     }
 

--- a/include/boost/heap/d_ary_heap.hpp
+++ b/include/boost/heap/d_ary_heap.hpp
@@ -66,7 +66,11 @@ class d_ary_heap:
     typedef typename heap_base_maker::type super_t;
     typedef typename super_t::internal_type internal_type;
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     typedef typename heap_base_maker::allocator_argument::template rebind<internal_type>::other internal_type_allocator;
+#else
+    typedef typename std::allocator_traits<typename heap_base_maker::allocator_argument>::template rebind_alloc<internal_type> internal_type_allocator;
+#endif
     typedef std::vector<internal_type, internal_type_allocator> container_type;
     typedef typename container_type::const_iterator container_iterator;
 

--- a/include/boost/heap/detail/heap_node.hpp
+++ b/include/boost/heap/detail/heap_node.hpp
@@ -99,21 +99,35 @@ template <typename Node,
           typename Alloc>
 struct node_cloner
 {
+#ifndef BOOST_NO_CXX11_ALLOCATOR
+    typedef std::allocator_traits<Alloc> allocator_traits;
+#endif
+
     node_cloner(Alloc & allocator):
         allocator(allocator)
     {}
 
     Node * operator() (NodeBase const & node)
     {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         Node * ret = allocator.allocate(1);
         new (ret) Node(static_cast<Node const &>(node), allocator);
+#else
+        Node * ret = allocator_traits::allocate(allocator, 1);
+        allocator_traits::construct(allocator, ret, static_cast<Node const &>(node), allocator);
+#endif
         return ret;
     }
 
     Node * operator() (NodeBase const & node, Node * parent)
     {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         Node * ret = allocator.allocate(1);
         new (ret) Node(static_cast<Node const &>(node), allocator, parent);
+#else
+        Node * ret = allocator_traits::allocate(allocator, 1);
+        allocator_traits::construct(allocator, ret, static_cast<Node const &>(node), allocator, parent);
+#endif
         return ret;
     }
 
@@ -132,7 +146,12 @@ template <typename Node,
           typename Alloc>
 struct node_disposer
 {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     typedef typename Alloc::pointer node_pointer;
+#else
+    typedef std::allocator_traits<Alloc> allocator_traits;
+    typedef typename allocator_traits::pointer node_pointer;
+#endif
 
     node_disposer(Alloc & alloc):
         alloc_(alloc)
@@ -142,8 +161,13 @@ struct node_disposer
     {
         node_pointer n = static_cast<node_pointer>(base);
         n->clear_subtree(alloc_);
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         alloc_.destroy(n);
         alloc_.deallocate(n, 1);
+#else
+        allocator_traits::destroy(alloc_, n);
+        allocator_traits::deallocate(alloc_, n, 1);
+#endif
     }
 
     Alloc & alloc_;

--- a/include/boost/heap/detail/mutable_heap.hpp
+++ b/include/boost/heap/detail/mutable_heap.hpp
@@ -47,7 +47,11 @@ public:
 private:
     typedef std::pair<value_type, size_type> node_type;
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     typedef std::list<node_type, typename allocator_type::template rebind<node_type>::other> object_list;
+#else
+    typedef std::list<node_type, typename std::allocator_traits<allocator_type>::template rebind_alloc<node_type>> object_list;
+#endif
 
     typedef typename object_list::iterator list_iterator;
     typedef typename object_list::const_iterator const_list_iterator;
@@ -296,7 +300,11 @@ public:
         }
 
         std::priority_queue<iterator,
+#ifdef BOOST_NO_CXX11_ALLOCATOR
                             std::vector<iterator, typename allocator_type::template rebind<iterator>::other >,
+#else
+                            std::vector<iterator, typename std::allocator_traits<allocator_type>::template rebind_alloc<iterator> >,
+#endif
                             indirect_cmp
                            > unvisited_nodes;
         const priority_queue_mutable_wrapper * q_;

--- a/include/boost/heap/detail/ordered_adaptor_iterator.hpp
+++ b/include/boost/heap/detail/ordered_adaptor_iterator.hpp
@@ -133,7 +133,11 @@ private:
     }
 
     std::priority_queue<size_t,
+#ifdef BOOST_NO_CXX11_ALLOCATOR
                         std::vector<size_t, typename Alloc::template rebind<size_t>::other >,
+#else
+                        std::vector<size_t, typename std::allocator_traits<Alloc>::template rebind_alloc<size_t> >,
+#endif
                         compare_by_heap_value
                        > unvisited_nodes;
 };

--- a/include/boost/heap/detail/stable_heap.hpp
+++ b/include/boost/heap/detail/stable_heap.hpp
@@ -566,12 +566,22 @@ struct make_heap_base
 template <typename Alloc>
 struct extract_allocator_types
 {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     typedef typename Alloc::size_type size_type;
     typedef typename Alloc::difference_type difference_type;
     typedef typename Alloc::reference reference;
     typedef typename Alloc::const_reference const_reference;
     typedef typename Alloc::pointer pointer;
     typedef typename Alloc::const_pointer const_pointer;
+#else
+    typedef std::allocator_traits<Alloc> traits;
+    typedef typename traits::size_type size_type;
+    typedef typename traits::difference_type difference_type;
+    typedef typename Alloc::value_type& reference;
+    typedef typename const Alloc::value_type& const_reference;
+    typedef typename traits::pointer pointer;
+    typedef typename traits::const_pointer const_pointer;
+#endif
 };
 
 

--- a/include/boost/heap/detail/tree_iterator.hpp
+++ b/include/boost/heap/detail/tree_iterator.hpp
@@ -80,7 +80,11 @@ struct unordered_tree_iterator_storage
         return data_.empty();
     }
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     std::vector<HandleType, typename Alloc::template rebind<HandleType>::other > data_;
+#else
+    std::vector<HandleType, typename std::allocator_traits<Alloc>::template rebind_alloc<HandleType> > data_;
+#endif
 };
 
 template <typename ValueType,
@@ -133,7 +137,11 @@ struct ordered_tree_iterator_storage:
     }
 
     std::priority_queue<HandleType,
+#ifdef BOOST_NO_CXX11_ALLOCATOR
                         std::vector<HandleType, typename Alloc::template rebind<HandleType>::other>,
+#else
+                        std::vector<HandleType, typename std::allocator_traits<Alloc>::template rebind_alloc<HandleType> >,
+#endif
                         compare_values_by_handle> data_;
 };
 

--- a/include/boost/heap/fibonacci_heap.hpp
+++ b/include/boost/heap/fibonacci_heap.hpp
@@ -58,7 +58,11 @@ struct make_fibonacci_heap_base
     typedef typename detail::make_heap_base<T, Parspec, constant_time_size>::compare_argument compare_argument;
     typedef marked_heap_node<typename base_type::internal_type> node_type;
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     typedef typename allocator_argument::template rebind<node_type>::other allocator_type;
+#else
+    typedef typename std::allocator_traits<allocator_argument>::template rebind_alloc<node_type> allocator_type;
+#endif
 
     struct type:
         base_type,
@@ -154,8 +158,14 @@ private:
         typedef typename base_maker::compare_argument value_compare;
         typedef typename base_maker::allocator_type allocator_type;
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         typedef typename allocator_type::pointer node_pointer;
         typedef typename allocator_type::const_pointer const_node_pointer;
+#else
+        typedef std::allocator_traits<allocator_type> allocator_traits;
+        typedef typename allocator_traits::pointer node_pointer;
+        typedef typename allocator_traits::const_pointer const_node_pointer;
+#endif
 
         typedef detail::heap_node_list node_list_type;
         typedef typename node_list_type::iterator node_list_iterator;
@@ -201,6 +211,9 @@ public:
     typedef typename implementation_defined::difference_type difference_type;
     typedef typename implementation_defined::value_compare value_compare;
     typedef typename implementation_defined::allocator_type allocator_type;
+#ifndef BOOST_NO_CXX11_ALLOCATOR
+    typedef typename implementation_defined::allocator_traits allocator_traits;
+#endif
     typedef typename implementation_defined::reference reference;
     typedef typename implementation_defined::const_reference const_reference;
     typedef typename implementation_defined::pointer pointer;
@@ -299,7 +312,12 @@ public:
     /// \copydoc boost::heap::priority_queue::max_size
     size_type max_size(void) const
     {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         return allocator_type::max_size();
+#else
+        const allocator_type& alloc = *this;
+        return allocator_traits::max_size(alloc);
+#endif
     }
 
     /// \copydoc boost::heap::priority_queue::clear
@@ -347,9 +365,14 @@ public:
     {
         size_holder::increment();
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         node_pointer n = allocator_type::allocate(1);
-
         new(n) node(super_t::make_node(v));
+#else
+        allocator_type& alloc = *this;
+        node_pointer n = allocator_traits::allocate(alloc, 1);
+        allocator_traits::construct(alloc, n, super_t::make_node(v));
+#endif
         roots.push_front(*n);
 
         if (!top_element || super_t::operator()(top_element->value, n->value))
@@ -371,9 +394,14 @@ public:
     {
         size_holder::increment();
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         node_pointer n = allocator_type::allocate(1);
-
         new(n) node(super_t::make_node(std::forward<Args>(args)...));
+#else
+        allocator_type& alloc = *this;
+        node_pointer n = allocator_traits::allocate(alloc, 1);
+        allocator_traits::construct(alloc, n, super_t::make_node(std::forward<Args>(args)...));
+#endif
         roots.push_front(*n);
 
         if (!top_element || super_t::operator()(top_element->value, n->value))
@@ -741,8 +769,14 @@ private:
     {
         add_children_to_root(erased_node);
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         erased_node->~node();
         allocator_type::deallocate(erased_node, 1);
+#else
+        allocator_type& alloc = *this;
+        allocator_traits::destroy(alloc, erased_node);
+        allocator_traits::deallocate(alloc, erased_node, 1);
+#endif
 
         size_holder::decrement();
         if (!empty())

--- a/include/boost/heap/pairing_heap.hpp
+++ b/include/boost/heap/pairing_heap.hpp
@@ -58,7 +58,11 @@ struct make_pairing_heap_base
 
     typedef heap_node<typename base_type::internal_type, false> node_type;
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     typedef typename allocator_argument::template rebind<node_type>::other allocator_type;
+#else
+    typedef typename std::allocator_traits<allocator_argument>::template rebind_alloc<node_type> allocator_type;
+#endif
 
     struct type:
         base_type,
@@ -158,8 +162,14 @@ private:
         typedef typename base_maker::compare_argument value_compare;
         typedef typename base_maker::allocator_type allocator_type;
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         typedef typename allocator_type::pointer node_pointer;
         typedef typename allocator_type::const_pointer const_node_pointer;
+#else
+        typedef std::allocator_traits<allocator_type> allocator_traits;
+        typedef typename allocator_traits::pointer node_pointer;
+        typedef typename allocator_traits::const_pointer const_node_pointer;
+#endif
 
         typedef detail::heap_node_list node_list_type;
         typedef typename node_list_type::iterator node_list_iterator;
@@ -213,6 +223,9 @@ public:
     typedef typename implementation_defined::difference_type difference_type;
     typedef typename implementation_defined::value_compare value_compare;
     typedef typename implementation_defined::allocator_type allocator_type;
+#ifndef BOOST_NO_CXX11_ALLOCATOR
+    typedef typename implementation_defined::allocator_traits allocator_traits;
+#endif
     typedef typename implementation_defined::reference reference;
     typedef typename implementation_defined::const_reference const_reference;
     typedef typename implementation_defined::pointer pointer;
@@ -302,7 +315,12 @@ public:
     /// \copydoc boost::heap::priority_queue::max_size
     size_type max_size(void) const
     {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         return allocator_type::max_size();
+#else
+        const allocator_type& alloc = *this;
+        return allocator_traits::max_size(alloc);
+#endif
     }
 
     /// \copydoc boost::heap::priority_queue::clear
@@ -312,8 +330,14 @@ public:
             return;
 
         root->template clear_subtree<allocator_type>(*this);
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         root->~node();
         allocator_type::deallocate(root, 1);
+#else
+        allocator_type& alloc = *this;
+        allocator_traits::destroy(alloc, root);
+        allocator_traits::deallocate(alloc, root, 1);
+#endif
         root = NULL;
         size_holder::set_size(0);
     }
@@ -354,10 +378,14 @@ public:
     {
         size_holder::increment();
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         node_pointer n = allocator_type::allocate(1);
-
         new(n) node(super_t::make_node(v));
-
+#else
+        allocator_type& alloc = *this;
+        node_pointer n = allocator_traits::allocate(alloc, 1);
+        allocator_traits::construct(alloc, n, super_t::make_node(v));
+#endif
         merge_node(n);
         return handle_type(n);
     }
@@ -378,10 +406,14 @@ public:
     {
         size_holder::increment();
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         node_pointer n = allocator_type::allocate(1);
-
         new(n) node(super_t::make_node(std::forward<Args>(args)...));
-
+#else
+        allocator_type& alloc = *this;
+        node_pointer n = allocator_traits::allocate(alloc, 1);
+        allocator_traits::construct(alloc, n, super_t::make_node(std::forward<Args>(args)...));
+#endif
         merge_node(n);
         return handle_type(n);
     }
@@ -527,8 +559,14 @@ public:
         }
 
         size_holder::decrement();
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         n->~node();
         allocator_type::deallocate(n, 1);
+#else
+        allocator_type& alloc = *this;
+        allocator_traits::destroy(alloc, n);
+        allocator_traits::deallocate(alloc, n, 1);
+#endif
     }
 
     /// \copydoc boost::heap::priority_queue::begin

--- a/include/boost/heap/priority_queue.hpp
+++ b/include/boost/heap/priority_queue.hpp
@@ -67,7 +67,11 @@ class priority_queue:
 
     typedef typename heap_base_maker::type super_t;
     typedef typename super_t::internal_type internal_type;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     typedef typename heap_base_maker::allocator_argument::template rebind<internal_type>::other internal_type_allocator;
+#else
+    typedef typename std::allocator_traits<typename heap_base_maker::allocator_argument>::template rebind_alloc<internal_type> internal_type_allocator;
+#endif
     typedef std::vector<internal_type, internal_type_allocator> container_type;
 
     template <typename Heap1, typename Heap2>
@@ -83,6 +87,9 @@ class priority_queue:
         typedef detail::stable_heap_iterator<T, typename container_type::const_iterator, super_t> iterator;
         typedef iterator const_iterator;
         typedef typename container_type::allocator_type allocator_type;
+#ifndef BOOST_NO_CXX11_ALLOCATOR
+        typedef typename std::allocator_traits<allocator_type> allocator_traits;
+#endif
     };
 #endif
 
@@ -92,6 +99,9 @@ public:
     typedef typename implementation_defined::difference_type difference_type;
     typedef typename implementation_defined::value_compare value_compare;
     typedef typename implementation_defined::allocator_type allocator_type;
+#ifndef BOOST_NO_CXX11_ALLOCATOR
+    typedef typename implementation_defined::allocator_traits allocator_traits;
+#endif
     typedef typename implementation_defined::reference reference;
     typedef typename implementation_defined::const_reference const_reference;
     typedef typename implementation_defined::pointer pointer;

--- a/include/boost/heap/skew_heap.hpp
+++ b/include/boost/heap/skew_heap.hpp
@@ -192,7 +192,11 @@ struct make_skew_heap_base
 
     typedef skew_heap_node<typename base_type::internal_type, store_parent_pointer> node_type;
 
+#ifdef BOOST_NO_CXX11_ALLOCATOR
     typedef typename allocator_argument::template rebind<node_type>::other allocator_type;
+#else
+    typedef typename std::allocator_traits<allocator_argument>::template rebind_alloc<node_type> allocator_type;
+#endif
 
     struct type:
         base_type,
@@ -290,8 +294,14 @@ class skew_heap:
         typedef typename base_maker::allocator_type allocator_type;
 
         typedef typename base_maker::node_type node;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         typedef typename allocator_type::pointer node_pointer;
         typedef typename allocator_type::const_pointer const_node_pointer;
+#else
+        typedef std::allocator_traits<allocator_type> allocator_traits;
+        typedef typename allocator_traits::pointer node_pointer;
+        typedef typename allocator_traits::const_pointer const_node_pointer;
+#endif
 
         typedef detail::value_extractor<value_type, internal_type, super_t> value_extractor;
 
@@ -345,6 +355,9 @@ public:
     typedef typename implementation_defined::difference_type difference_type;
     typedef typename implementation_defined::value_compare value_compare;
     typedef typename implementation_defined::allocator_type allocator_type;
+#ifndef BOOST_NO_CXX11_ALLOCATOR
+    typedef typename implementation_defined::allocator_traits allocator_traits;
+#endif
     typedef typename implementation_defined::reference reference;
     typedef typename implementation_defined::const_reference const_reference;
     typedef typename implementation_defined::pointer pointer;
@@ -462,7 +475,12 @@ public:
     /// \copydoc boost::heap::priority_queue::max_size
     size_type max_size(void) const
     {
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         return allocator_type::max_size();
+#else
+        const allocator_type& alloc = *this;
+        return allocator_traits::max_size(alloc);
+#endif
     }
 
     /// \copydoc boost::heap::priority_queue::clear
@@ -472,9 +490,14 @@ public:
             return;
 
         root->template clear_subtree<allocator_type>(*this);
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         root->~node();
         allocator_type::deallocate(root, 1);
-
+#else
+        allocator_type& alloc = *this;
+        allocator_traits::destroy(alloc, root);
+        allocator_traits::deallocate(alloc, root, 1);
+#endif
         root = NULL;
         size_holder::set_size(0);
     }
@@ -521,7 +544,14 @@ public:
             BOOST_HEAP_ASSERT(size_holder::get_size() == 0);
 
         top->~node();
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+        top->~node();
         allocator_type::deallocate(top, 1);
+#else
+        allocator_type& alloc = *this;
+        allocator_traits::destroy(alloc, top);
+        allocator_traits::deallocate(alloc, top, 1);
+#endif
         sanity_check();
     }
 
@@ -642,8 +672,14 @@ public:
         size_holder::decrement();
 
         sanity_check();
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         this_node->~node();
         allocator_type::deallocate(this_node, 1);
+#else
+        allocator_type& alloc = *this;
+        allocator_traits::destroy(alloc, this_node);
+        allocator_traits::deallocate(alloc, this_node, 1);
+#endif
     }
 
     /**
@@ -794,9 +830,14 @@ private:
     {
         size_holder::increment();
 
-        node_pointer n = super_t::allocate(1);
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+        node_pointer n = allocator_type::allocate(1);
         new(n) node(super_t::make_node(v));
-
+#else
+        allocator_type& alloc = *this;
+        node_pointer n = allocator_traits::allocate(alloc, 1);
+        allocator_traits::construct(alloc, n, super_t::make_node(v));
+#endif
         merge_node(n);
         return n;
     }
@@ -807,9 +848,14 @@ private:
     {
         size_holder::increment();
 
-        node_pointer n = super_t::allocate(1);
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+        node_pointer n = allocator_type::allocate(1);
         new(n) node(super_t::make_node(std::forward<Args>(args)...));
-
+#else
+        allocator_type& alloc = *this;
+        node_pointer n = allocator_traits::allocate(alloc, 1);
+        allocator_traits::construct(alloc, n, super_t::make_node(std::forward<Args>(args)...));
+#endif
         merge_node(n);
         return n;
     }
@@ -836,9 +882,14 @@ private:
         if (rhs.empty())
             return;
 
+        allocator_type& alloc = *this;
+#ifdef BOOST_NO_CXX11_ALLOCATOR
         root = allocator_type::allocate(1);
-
-        new(root) node(*rhs.root, static_cast<allocator_type&>(*this), NULL);
+        new(root) node(*rhs.root, alloc, NULL);
+#else
+        root = allocator_traits::allocate(alloc, 1);
+        allocator_traits::construct(alloc, root, *rhs.root, alloc, nullptr);
+#endif
     }
 
     void merge_node(node_pointer other)


### PR DESCRIPTION
Replace them by their cousins from std::allocator_traits.

Signed-off-by: Daniela Engert <dani@ngrt.de>