### PR TITLE
Fix expected nested-name-specifier before ‘const’ error

### DIFF
--- a/include/boost/heap/detail/stable_heap.hpp
+++ b/include/boost/heap/detail/stable_heap.hpp
@@ -578,7 +578,7 @@ struct extract_allocator_types
     typedef typename traits::size_type size_type;
     typedef typename traits::difference_type difference_type;
     typedef typename Alloc::value_type& reference;
-    typedef typename const Alloc::value_type& const_reference;
+    typedef typename Alloc::value_type const& const_reference;
     typedef typename traits::pointer pointer;
     typedef typename traits::const_pointer const_pointer;
 #endif


### PR DESCRIPTION
2b45bfef7f722b729a29419caa2c47be445a3e79 introduces a regression:
```
/home/miha/foss/boost/boost/heap/detail/stable_heap.hpp:581:22: error: expected nested-name-specifier before ‘const’
     typedef typename const Alloc::value_type& const_reference;
                      ^~~~~
/home/miha/foss/boost/boost/heap/detail/stable_heap.hpp:581:35: error: invalid use of qualified-name ‘Alloc::value_type’
     typedef typename const Alloc::value_type& const_reference;
                                   ^~~~~~~~~~
```

PR flips the const qualifier to the right side.