### PR TITLE
Add missing includes

### DIFF
--- a/include/boost/heap/d_ary_heap.hpp
+++ b/include/boost/heap/d_ary_heap.hpp
@@ -16,6 +16,7 @@
 #include <boost/assert.hpp>
 
 #include <boost/mem_fn.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/heap/detail/heap_comparison.hpp>
 #include <boost/heap/detail/ordered_adaptor_iterator.hpp>
 #include <boost/heap/detail/stable_heap.hpp>

--- a/include/boost/heap/detail/heap_comparison.hpp
+++ b/include/boost/heap/detail/heap_comparison.hpp
@@ -11,6 +11,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/static_assert.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/concept/assert.hpp>
 #include <boost/heap/heap_concepts.hpp>
 

--- a/include/boost/heap/detail/tree_iterator.hpp
+++ b/include/boost/heap/detail/tree_iterator.hpp
@@ -12,6 +12,7 @@
 #include <functional>
 #include <vector>
 
+#include <boost/mpl/if.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <queue>
 

--- a/include/boost/heap/heap_merge.hpp
+++ b/include/boost/heap/heap_merge.hpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 
+#include <boost/mpl/if.hpp>
 #include <boost/concept/assert.hpp>
 #include <boost/heap/heap_concepts.hpp>
 #include <boost/type_traits/is_same.hpp>

--- a/include/boost/heap/policies.hpp
+++ b/include/boost/heap/policies.hpp
@@ -13,6 +13,7 @@
 #include <boost/mpl/bool.hpp>
 #include <boost/mpl/int.hpp>
 #include <boost/mpl/void.hpp>
+#include <boost/mpl/if.hpp>
 #include <boost/concept_check.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE

--- a/include/boost/heap/skew_heap.hpp
+++ b/include/boost/heap/skew_heap.hpp
@@ -15,6 +15,7 @@
 
 #include <boost/assert.hpp>
 #include <boost/array.hpp>
+#include <boost/mpl/if.hpp>
 
 #include <boost/heap/detail/heap_comparison.hpp>
 #include <boost/heap/detail/heap_node.hpp>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -3,21 +3,37 @@
 # (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 import testing ;
+import path ;
+import regex ;
 
 rule test_all
 {
-   local all_rules = ;
+    local all_rules ;
+    local file ;
+    local headers_path = [ path.make $(BOOST_ROOT)/libs/heap/include/boost/heap ] ;
+    for file in [ path.glob-tree $(headers_path) : *.hpp : detail ]
+    {
+        local rel_file = [ path.relative-to $(headers_path) $(file) ] ;
+        # Note: The test name starts with '~' in order to group these tests in the test report table, preferably at the end.
+        #       All '/' are replaced with '-' because apparently test scripts have a problem with test names containing slashes.
+        local test_name = [ regex.replace ~hdr/$(rel_file) "/" "-" ] ;
+        #ECHO $(rel_file) ;
+        all_rules += [ compile self_contained_header.cpp : <define>"BOOST_HEAP_TEST_HEADER=$(rel_file)" <dependency>$(file) : $(test_name) ] ;
+    }
 
-   for local fileb in [ glob *.cpp ]
+   for file in [ glob *.cpp ]
    {
-       all_rules += [ run $(fileb)
-      :  # additional args
-      :  # test-files
-      : <library>/boost/test//boost_unit_test_framework # requirements
-      ] ;
+        if [ path.basename $(file) ] != "self_contained_header.cpp"
+        {
+            all_rules += [ run $(file)
+                :  # additional args
+                :  # test-files
+                : <library>/boost/test//boost_unit_test_framework # requirements
+            ] ;
+        }
    }
 
     return $(all_rules) ;
 }
 
-test-suite heap : [ test_all r ] : <threading>multi ;
+test-suite heap : [ test_all ] : <threading>multi ;

--- a/test/self_contained_header.cpp
+++ b/test/self_contained_header.cpp
@@ -1,0 +1,22 @@
+/*
+ *            Copyright Andrey Semashev 2018.
+ * Distributed under the Boost Software License, Version 1.0.
+ *    (See accompanying file LICENSE_1_0.txt or copy at
+ *          http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*!
+ * \file   self_contained_header.cpp
+ * \author Andrey Semashev
+ * \date   28.10.2018
+ *
+ * \brief  This file contains a test boilerplate for checking that every public header is self-contained and does not have any missing #includes.
+ */
+
+#define BOOST_HEAP_TEST_INCLUDE_HEADER() <boost/heap/BOOST_HEAP_TEST_HEADER>
+
+#include BOOST_HEAP_TEST_INCLUDE_HEADER()
+
+int main(int, char*[])
+{
+    return 0;
+}


### PR DESCRIPTION
This should fix https://github.com/boostorg/heap/issues/12 and also adds a test for headers being self-contained.