### PR TITLE
Drop dependency on Boost.Mpl in favor of Boost.TypeTraits

### DIFF
--- a/include/boost/heap/binomial_heap.hpp
+++ b/include/boost/heap/binomial_heap.hpp
@@ -19,6 +19,7 @@
 #include <boost/heap/detail/heap_node.hpp>
 #include <boost/heap/detail/stable_heap.hpp>
 #include <boost/heap/detail/tree_iterator.hpp>
+#include <boost/type_traits/integral_constant.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
 #pragma once
@@ -48,7 +49,7 @@ struct make_binomial_heap_base
 {
     static const bool constant_time_size = parameter::binding<Parspec,
                                                               tag::constant_time_size,
-                                                              boost::mpl::true_
+                                                              boost::true_type
                                                              >::type::value;
     typedef typename detail::make_heap_base<T, Parspec, constant_time_size>::type base_type;
     typedef typename detail::make_heap_base<T, Parspec, constant_time_size>::allocator_argument allocator_argument;

--- a/include/boost/heap/d_ary_heap.hpp
+++ b/include/boost/heap/d_ary_heap.hpp
@@ -425,7 +425,7 @@ struct select_dary_heap
 {
     static const bool is_mutable = extract_mutable<BoundArgs>::value;
 
-    typedef typename mpl::if_c< is_mutable,
+    typedef typename boost::conditional< is_mutable,
                                 priority_queue_mutable_wrapper<d_ary_heap<T, BoundArgs, nop_index_updater > >,
                                 d_ary_heap<T, BoundArgs, nop_index_updater >
                               >::type type;
@@ -589,7 +589,7 @@ public:
     }
 
     /// \copydoc boost::heap::priority_queue::push
-    typename mpl::if_c<is_mutable, handle_type, void>::type push(value_type const & v)
+    typename boost::conditional<is_mutable, handle_type, void>::type push(value_type const & v)
     {
         return super_t::push(v);
     }
@@ -597,7 +597,7 @@ public:
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
     /// \copydoc boost::heap::priority_queue::emplace
     template <class... Args>
-    typename mpl::if_c<is_mutable, handle_type, void>::type emplace(Args&&... args)
+    typename boost::conditional<is_mutable, handle_type, void>::type emplace(Args&&... args)
     {
         return super_t::emplace(std::forward<Args>(args)...);
     }

--- a/include/boost/heap/detail/heap_comparison.hpp
+++ b/include/boost/heap/detail/heap_comparison.hpp
@@ -13,6 +13,7 @@
 #include <boost/static_assert.hpp>
 #include <boost/concept/assert.hpp>
 #include <boost/heap/heap_concepts.hpp>
+#include <boost/type_traits/conditional.hpp>
 
 #ifdef BOOST_HEAP_SANITYCHECKS
 #define BOOST_HEAP_ASSERT BOOST_ASSERT
@@ -136,7 +137,7 @@ bool heap_equality(Heap1 const & lhs, Heap2 const & rhs)
 {
     const bool use_ordered_iterators = Heap1::has_ordered_iterators && Heap2::has_ordered_iterators;
 
-    typedef typename boost::mpl::if_c<use_ordered_iterators,
+    typedef typename boost::conditional<use_ordered_iterators,
                                       heap_equivalence_iteration,
                                       heap_equivalence_copy
                                      >::type equivalence_check;
@@ -225,7 +226,7 @@ bool heap_compare(Heap1 const & lhs, Heap2 const & rhs)
 {
     const bool use_ordered_iterators = Heap1::has_ordered_iterators && Heap2::has_ordered_iterators;
 
-    typedef typename boost::mpl::if_c<use_ordered_iterators,
+    typedef typename boost::conditional<use_ordered_iterators,
                                       heap_compare_iteration,
                                       heap_compare_copy
                                      >::type compare_check;

--- a/include/boost/heap/detail/heap_node.hpp
+++ b/include/boost/heap/detail/heap_node.hpp
@@ -12,7 +12,7 @@
 #include <boost/assert.hpp>
 #include <boost/static_assert.hpp>
 #include <boost/intrusive/list.hpp>
-#include <boost/mpl/if.hpp>
+#include <boost/type_traits/conditional.hpp>
 
 #ifdef BOOST_HEAP_SANITYCHECKS
 #define BOOST_HEAP_ASSERT BOOST_ASSERT
@@ -26,11 +26,10 @@ namespace heap   {
 namespace detail {
 
 namespace bi = boost::intrusive;
-namespace mpl = boost::mpl;
 
 template <bool auto_unlink = false>
 struct heap_node_base:
-    bi::list_base_hook<typename mpl::if_c<auto_unlink,
+    bi::list_base_hook<typename boost::conditional<auto_unlink,
                                           bi::link_mode<bi::auto_unlink>,
                                           bi::link_mode<bi::safe_link>
                                          >::type

--- a/include/boost/heap/detail/tree_iterator.hpp
+++ b/include/boost/heap/detail/tree_iterator.hpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include <boost/iterator/iterator_adaptor.hpp>
+#include <boost/type_traits/conditional.hpp>
 #include <queue>
 
 namespace boost  {
@@ -195,7 +196,7 @@ class tree_iterator:
 
     friend class boost::iterator_core_access;
 
-    typedef typename boost::mpl::if_c< ordered_iterator,
+    typedef typename boost::conditional< ordered_iterator,
                                        ordered_tree_iterator_storage<ValueType, const Node*, Alloc, ValueCompare, ValueExtractor>,
                                        unordered_tree_iterator_storage<const Node*, Alloc, ValueCompare>
                                      >::type

--- a/include/boost/heap/fibonacci_heap.hpp
+++ b/include/boost/heap/fibonacci_heap.hpp
@@ -20,6 +20,7 @@
 #include <boost/heap/detail/heap_node.hpp>
 #include <boost/heap/detail/stable_heap.hpp>
 #include <boost/heap/detail/tree_iterator.hpp>
+#include <boost/type_traits/integral_constant.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
 #pragma once
@@ -50,7 +51,7 @@ struct make_fibonacci_heap_base
 {
     static const bool constant_time_size = parameter::binding<Parspec,
                                                               tag::constant_time_size,
-                                                              boost::mpl::true_
+                                                              boost::true_type
                                                              >::type::value;
 
     typedef typename detail::make_heap_base<T, Parspec, constant_time_size>::type base_type;

--- a/include/boost/heap/heap_merge.hpp
+++ b/include/boost/heap/heap_merge.hpp
@@ -13,6 +13,7 @@
 
 #include <boost/concept/assert.hpp>
 #include <boost/heap/heap_concepts.hpp>
+#include <boost/type_traits/conditional.hpp>
 #include <boost/type_traits/is_same.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
@@ -41,7 +42,7 @@ struct heap_merge_emulate
         }
     };
 
-    typedef typename boost::mpl::if_c<Heap1::has_reserve,
+    typedef typename boost::conditional<Heap1::has_reserve,
                                       reserver,
                                       dummy_reserver>::type space_reserver;
 
@@ -85,7 +86,7 @@ template <typename Heap>
 struct heap_merge_same
 {
     static const bool is_mergable = Heap::is_mergable;
-    typedef typename boost::mpl::if_c<is_mergable,
+    typedef typename boost::conditional<is_mergable,
                                       heap_merge_same_mergable<Heap>,
                                       heap_merge_emulate<Heap, Heap>
                                      >::type heap_merger;
@@ -117,7 +118,7 @@ void heap_merge(Heap1 & lhs, Heap2 & rhs)
 
     const bool same_heaps = boost::is_same<Heap1, Heap2>::value;
 
-    typedef typename boost::mpl::if_c<same_heaps,
+    typedef typename boost::conditional<same_heaps,
                                       detail::heap_merge_same<Heap1>,
                                       detail::heap_merge_emulate<Heap1, Heap2>
                                      >::type heap_merger;

--- a/include/boost/heap/pairing_heap.hpp
+++ b/include/boost/heap/pairing_heap.hpp
@@ -20,6 +20,7 @@
 #include <boost/heap/policies.hpp>
 #include <boost/heap/detail/stable_heap.hpp>
 #include <boost/heap/detail/tree_iterator.hpp>
+#include <boost/type_traits/integral_constant.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
 #pragma once
@@ -50,7 +51,7 @@ struct make_pairing_heap_base
 {
     static const bool constant_time_size = parameter::binding<Parspec,
                                                               tag::constant_time_size,
-                                                              boost::mpl::true_
+                                                              boost::true_type
                                                              >::type::value;
     typedef typename detail::make_heap_base<T, Parspec, constant_time_size>::type base_type;
     typedef typename detail::make_heap_base<T, Parspec, constant_time_size>::allocator_argument allocator_argument;

--- a/include/boost/heap/policies.hpp
+++ b/include/boost/heap/policies.hpp
@@ -10,10 +10,10 @@
 #define BOOST_HEAP_POLICIES_HPP
 
 #include <boost/parameter.hpp>
-#include <boost/mpl/bool.hpp>
-#include <boost/mpl/int.hpp>
-#include <boost/mpl/void.hpp>
 #include <boost/concept_check.hpp>
+#include <boost/type_traits/conditional.hpp>
+#include <boost/type_traits/integral_constant.hpp>
+#include <boost/type_traits/is_void.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
 #pragma once
@@ -30,14 +30,14 @@ namespace tag { struct stable; }
 
 template <bool T>
 struct stable:
-    boost::parameter::template_keyword<tag::stable, boost::mpl::bool_<T> >
+    boost::parameter::template_keyword<tag::stable, boost::integral_constant<bool, T> >
 {};
 
 namespace tag { struct mutable_; }
 
 template <bool T>
 struct mutable_:
-    boost::parameter::template_keyword<tag::mutable_, boost::mpl::bool_<T> >
+    boost::parameter::template_keyword<tag::mutable_, boost::integral_constant<bool, T> >
 {};
 
 
@@ -45,41 +45,39 @@ namespace tag { struct constant_time_size; }
 
 template <bool T>
 struct constant_time_size:
-    boost::parameter::template_keyword<tag::constant_time_size, boost::mpl::bool_<T> >
+    boost::parameter::template_keyword<tag::constant_time_size, boost::integral_constant<bool, T> >
 {};
 
 namespace tag { struct store_parent_pointer; }
 
 template <bool T>
 struct store_parent_pointer:
-    boost::parameter::template_keyword<tag::store_parent_pointer, boost::mpl::bool_<T> >
+    boost::parameter::template_keyword<tag::store_parent_pointer, boost::integral_constant<bool, T> >
 {};
 
 namespace tag { struct arity; }
 
 template <unsigned int T>
 struct arity:
-    boost::parameter::template_keyword<tag::arity, boost::mpl::int_<T> >
+    boost::parameter::template_keyword<tag::arity, boost::integral_constant<int, T> >
 {};
 
 namespace tag { struct objects_per_page; }
 
 template <unsigned int T>
 struct objects_per_page:
-    boost::parameter::template_keyword<tag::objects_per_page, boost::mpl::int_<T> >
+    boost::parameter::template_keyword<tag::objects_per_page, boost::integral_constant<int, T> >
 {};
 
 BOOST_PARAMETER_TEMPLATE_KEYWORD(stability_counter_type)
 
 namespace detail {
 
-namespace mpl = boost::mpl;
-
 template <typename bound_args, typename tag_type>
 struct has_arg
 {
-    typedef typename boost::parameter::binding<bound_args, tag_type, mpl::void_>::type type;
-    static const bool value = mpl::is_not_void_<type>::type::value;
+    typedef typename boost::parameter::binding<bound_args, tag_type, void>::type type;
+    static const bool value = !boost::is_void<type>::value;
 };
 
 template <typename bound_args>
@@ -87,9 +85,9 @@ struct extract_stable
 {
     static const bool has_stable = has_arg<bound_args, tag::stable>::value;
 
-    typedef typename mpl::if_c<has_stable,
+    typedef typename boost::conditional<has_stable,
                                typename has_arg<bound_args, tag::stable>::type,
-                               mpl::bool_<false>
+                               boost::false_type
                               >::type stable_t;
 
     static const bool value = stable_t::value;
@@ -100,9 +98,9 @@ struct extract_mutable
 {
     static const bool has_mutable = has_arg<bound_args, tag::mutable_>::value;
 
-    typedef typename mpl::if_c<has_mutable,
+    typedef typename boost::conditional<has_mutable,
                                typename has_arg<bound_args, tag::mutable_>::type,
-                               mpl::bool_<false>
+                               boost::false_type
                               >::type mutable_t;
 
     static const bool value = mutable_t::value;

--- a/include/boost/heap/skew_heap.hpp
+++ b/include/boost/heap/skew_heap.hpp
@@ -20,6 +20,7 @@
 #include <boost/heap/detail/heap_node.hpp>
 #include <boost/heap/detail/stable_heap.hpp>
 #include <boost/heap/detail/tree_iterator.hpp>
+#include <boost/type_traits/integral_constant.hpp>
 
 #ifdef BOOST_HAS_PRAGMA_ONCE
 #pragma once
@@ -178,7 +179,7 @@ struct make_skew_heap_base
 {
     static const bool constant_time_size = parameter::binding<BoundArgs,
                                                               tag::constant_time_size,
-                                                              boost::mpl::true_
+                                                              boost::true_type
                                                              >::type::value;
 
     typedef typename make_heap_base<T, BoundArgs, constant_time_size>::type base_type;
@@ -188,7 +189,7 @@ struct make_skew_heap_base
     static const bool is_mutable = extract_mutable<BoundArgs>::value;
     static const bool store_parent_pointer = parameter::binding<BoundArgs,
                                                               tag::store_parent_pointer,
-                                                              boost::mpl::false_>::type::value || is_mutable;
+                                                              boost::false_type>::type::value || is_mutable;
 
     typedef skew_heap_node<typename base_type::internal_type, store_parent_pointer> node_type;
 
@@ -308,7 +309,7 @@ class skew_heap:
         typedef boost::array<node_pointer, 2> child_list_type;
         typedef typename child_list_type::iterator child_list_iterator;
 
-        typedef typename boost::mpl::if_c<false,
+        typedef typename boost::conditional<false,
                                         detail::recursive_tree_iterator<node,
                                                                         child_list_iterator,
                                                                         const value_type,
@@ -375,7 +376,7 @@ public:
     static const bool has_reserve = false;
     static const bool is_mutable = detail::extract_mutable<bound_args>::value;
 
-    typedef typename mpl::if_c<is_mutable, typename implementation_defined::handle_type, void*>::type handle_type;
+    typedef typename boost::conditional<is_mutable, typename implementation_defined::handle_type, void*>::type handle_type;
 
     /// \copydoc boost::heap::priority_queue::priority_queue(value_compare const &)
     explicit skew_heap(value_compare const & cmp = value_compare()):
@@ -433,9 +434,9 @@ public:
      * \b Complexity: Logarithmic (amortized).
      *
      * */
-    typename mpl::if_c<is_mutable, handle_type, void>::type push(value_type const & v)
+    typename boost::conditional<is_mutable, handle_type, void>::type push(value_type const & v)
     {
-        typedef typename mpl::if_c<is_mutable, push_handle, push_void>::type push_helper;
+        typedef typename boost::conditional<is_mutable, push_handle, push_void>::type push_helper;
         return push_helper::push(this, v);
     }
 
@@ -447,9 +448,9 @@ public:
      *
      * */
     template <typename... Args>
-    typename mpl::if_c<is_mutable, handle_type, void>::type emplace(Args&&... args)
+    typename boost::conditional<is_mutable, handle_type, void>::type emplace(Args&&... args)
     {
-        typedef typename mpl::if_c<is_mutable, push_handle, push_void>::type push_helper;
+        typedef typename boost::conditional<is_mutable, push_handle, push_void>::type push_helper;
         return push_helper::emplace(this, std::forward<Args>(args)...);
     }
 #endif

--- a/test/merge_heap_tests.hpp
+++ b/test/merge_heap_tests.hpp
@@ -66,7 +66,7 @@ struct pri_queue_test_heap_merge
 template <typename pri_queue>
 void run_merge_tests(void)
 {
-    boost::mpl::if_c<pri_queue::is_mergable,
+    boost::conditional<pri_queue::is_mergable,
                      pri_queue_test_merge<pri_queue>,
                      dummy_run
                     >::type::run();


### PR DESCRIPTION
Heap already depends on TypeTraits and this change just uses those facilities from TypeTraits (which are also now in the C++ standard library) instead of MPL.