### PR TITLE
Update <boost/heap/policies.hpp> and ".travis.yml"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@
 
 language: cpp
 
-sudo: false
-
 branches:
   only:
     - master
@@ -107,6 +105,8 @@ install:
   - cd ..
   - git clone -b $BOOST_BRANCH https://github.com/boostorg/boost.git boost-root
   - cd boost-root
+  - git submodule update --init tools/boost_install
+  - git submodule update --init libs/headers
   - git submodule update --init tools/build
   - git submodule update --init libs/config
   - git submodule update --init tools/boostdep

--- a/include/boost/heap/policies.hpp
+++ b/include/boost/heap/policies.hpp
@@ -11,7 +11,7 @@
 
 #include <boost/concept_check.hpp>
 #include <boost/parameter/name.hpp>
-#include <boost/parameter/aux_/template_keyword.hpp>
+#include <boost/parameter/template_keyword.hpp>
 #include <boost/parameter/aux_/void.hpp>
 #include <boost/parameter/binding.hpp>
 #include <boost/parameter/parameters.hpp>


### PR DESCRIPTION
<boost/heap/policies.hpp>
* Point #include statement to new location of header file.

".travis.yml"
* Add git statements for b2 cmake support.
* Remove "sudo: false" statement deprecated by Travis CI.