### PR TITLE
Fix initialization warning in Visual Studio 2017

### DIFF
--- a/include/boost/heap/detail/stable_heap.hpp
+++ b/include/boost/heap/detail/stable_heap.hpp
@@ -173,19 +173,21 @@ struct heap_base:
     heap_base(heap_base && rhs) BOOST_NOEXCEPT_IF(boost::is_nothrow_move_constructible<Cmp>::value):
 #ifndef BOOST_MSVC
         Cmp(std::move(static_cast<Cmp&>(rhs))),
-#else
-        cmp_(std::move(rhs.cmp_)),
 #endif
         size_holder_type(std::move(static_cast<size_holder_type&>(rhs)))
+#ifdef BOOST_MSVC
+        , cmp_(std::move(rhs.cmp_))
+#endif
     {}
 
     heap_base(heap_base const & rhs):
 #ifndef BOOST_MSVC
         Cmp(static_cast<Cmp const &>(rhs)),
-#else
-        cmp_(rhs.value_comp()),
 #endif
         size_holder_type(static_cast<size_holder_type const &>(rhs))
+#ifdef BOOST_MSVC
+        , cmp_(rhs.value_comp())
+#endif
     {}
 
     heap_base & operator=(heap_base && rhs) BOOST_NOEXCEPT_IF(boost::is_nothrow_move_assignable<Cmp>::value)


### PR DESCRIPTION
This fixes warning C5038 in Visual Studio 2017, which is caused by out-of-order initialization in the constructors of `heap_base`.
```
C:\dev\boost_1_70_0\boost/heap/detail/stable_heap.hpp(186): 
warning C5038: data member 'boost::heap::detail::heap_base<T,std::function<bool (ttk::SimplexId,ttk::SimplexId)>,true,unsigned __int64,false>::cmp_' will be initialized after base class 'boost::heap::detail::size_holder<true,size_t>' with [ T=ttk::SimplexId ]
```