### PR TITLE
Feature/minmax

### DIFF
--- a/doc/heap.qbk
+++ b/doc/heap.qbk
@@ -342,6 +342,12 @@ _heap_ provides the following data structures:
         constraints for the tree structure, all heap operations can be performed in O(log n).
      ]
     ]
+
+    [[[classref boost::heap::min_max_heap]]
+     [
+        [@https://en.wikipedia.org/wiki/Min-max_heap Min-max heaps] are a combination of a min heap and max heap in the same tree structure that allow to retrieve both the maximum and the minimum in constant time.
+     ]
+    ]
 ]
 
 [table Comparison of amortized complexity
@@ -355,6 +361,7 @@ _heap_ provides the following data structures:
 
     [[[classref boost::heap::pairing_heap]]         [[^O(1)]]   [O(2**2*log(log(N)))]   [O(log(N))] [O(2**2*log(log(N)))]   [O(2**2*log(log(N)))]  [O(2**2*log(log(N)))]    [O(2**2*log(log(N)))]   [O(2**2*log(log(N)))]]
     [[[classref boost::heap::skew_heap]]            [[^O(1)]]   [O(log(N))]     [O(log(N))]  [O(log(N))]   [O(log(N))]       [O(log(N))]     [O(log(N))]    [O(log(N+M))]]
+    [[[classref boost::heap::min_max_heap]]            [[^O(1)]]   [O(log(N))]     [O(log(N))]  [O(log(N))]   [O(log(N))]       [O(log(N))]     [O(log(N))]    [O((N+M)*log(N+M))]]
 ]
 
 
@@ -392,7 +399,7 @@ The data structures can be configured with [@boost:/libs/parameter/doc/html/inde
     ]
 
     [[[classref boost::heap::arity]]
-     [Specifies the arity of a d-ary heap. For details, please consult the class reference of [classref boost::heap::d_ary_heap]]
+     [Specifies the arity of a d-ary or a min-max heap. For details, please consult the class reference of [classref boost::heap::d_ary_heap] and [classref boost::heap::min_max_heap].]
     ]
 
     [[[classref boost::heap::store_parent_pointer]]

--- a/include/boost/heap/d_ary_heap.hpp
+++ b/include/boost/heap/d_ary_heap.hpp
@@ -38,13 +38,6 @@ namespace boost  {
 namespace heap   {
 namespace detail {
 
-struct nop_index_updater
-{
-    template <typename T>
-    static void run(T &, std::size_t)
-    {}
-};
-
 typedef parameter::parameters<boost::parameter::required<tag::arity>,
                               boost::parameter::optional<tag::allocator>,
                               boost::parameter::optional<tag::compare>,

--- a/include/boost/heap/detail/ilog2.hpp
+++ b/include/boost/heap/detail/ilog2.hpp
@@ -33,7 +33,7 @@ struct log2<unsigned int>
 {
     unsigned int operator()(unsigned int value)
     {
-        return sizeof(unsigned int)*8 - __builtin_clz(value - 1);
+        return sizeof(unsigned int)*8 - __builtin_clz(value) - 1;
     }
 };
 
@@ -42,7 +42,7 @@ struct log2<unsigned long>
 {
     unsigned long operator()(unsigned long value)
     {
-        return sizeof(unsigned long)*8 - __builtin_clzl(value - 1);
+        return sizeof(unsigned long)*8 - __builtin_clzl(value) - 1;
     }
 };
 

--- a/include/boost/heap/detail/mutable_heap.hpp
+++ b/include/boost/heap/detail/mutable_heap.hpp
@@ -23,6 +23,13 @@ namespace boost  {
 namespace heap   {
 namespace detail {
 
+struct nop_index_updater
+{
+    template <typename T>
+    static void run(T &, std::size_t)
+    {}
+};
+
 /* wrapper for a mutable heap container adaptors
  *
  * this wrapper introduces an additional indirection. the heap is not constructed from objects,

--- a/include/boost/heap/detail/mutable_heap.hpp
+++ b/include/boost/heap/detail/mutable_heap.hpp
@@ -628,17 +628,17 @@ public:
     void pop_min(void)
     {
         BOOST_ASSERT(!super_t::empty());
-        typename super_t::list_iterator q_top = super_t::q_.min();
+        typename super_t::list_iterator q_min = super_t::q_.min();
         super_t::q_.pop_min();
-        super_t::objects.erase(q_top);
+        super_t::objects.erase(q_min);
     }
 
     void pop_max(void)
     {
         BOOST_ASSERT(!super_t::empty());
-        typename super_t::list_iterator q_top = super_t::q_.max();
+        typename super_t::list_iterator q_max = super_t::q_.max();
         super_t::q_.pop_max();
-        super_t::objects.erase(q_top);
+        super_t::objects.erase(q_max);
     }
 
 public:
@@ -739,7 +739,7 @@ public:
     ordered_iterator ordered_begin(void) const
     {
         if (!super_t::empty())
-            return ordered_iterator(super_t::q_.min(), this, typename super_t::indirect_cmp(super_t::q_.value_comp()), typename super_t::q_type::ordered_iterator_dispatcher(super_t::q_.size()));
+            return ordered_iterator(super_t::q_.max(), this, typename super_t::indirect_cmp(super_t::q_.value_comp()), typename super_t::q_type::ordered_iterator_dispatcher(super_t::q_.size()));
         else
             return ordered_end();
     }
@@ -796,7 +796,7 @@ public:
     {
         if (!super_t::empty()) {
             if (1 < super_t::size()) {
-                typename super_t::const_list_iterator it = super_t::q_.max();
+                const typename super_t::const_list_iterator it = super_t::q_.min();
                 std::pair<typename super_t::size_type, typename super_t::size_type> initial_indexes;
                 initial_indexes.first = 1;
                 initial_indexes.second = std::min<typename super_t::size_type>(PriorityQueueType::D, super_t::size());
@@ -804,7 +804,7 @@ public:
                 return reverse_ordered_iterator(it, initial_indexes, this, indirect_reverse_cmp(super_t::q_.value_comp()), typename super_t::q_type::reverse_ordered_iterator_dispatcher(super_t::q_.size()));
             }
             else
-                return reverse_ordered_iterator(super_t::q_.max(), this, indirect_reverse_cmp(super_t::q_.value_comp()), typename super_t::q_type::reverse_ordered_iterator_dispatcher(super_t::q_.size()));
+                return reverse_ordered_iterator(super_t::q_.min(), this, indirect_reverse_cmp(super_t::q_.value_comp()), typename super_t::q_type::reverse_ordered_iterator_dispatcher(super_t::q_.size()));
         }
         else
             return reverse_ordered_end();

--- a/include/boost/heap/detail/mutable_heap.hpp
+++ b/include/boost/heap/detail/mutable_heap.hpp
@@ -51,7 +51,7 @@ public:
     typedef typename PriorityQueueType::const_pointer const_pointer;
     static const bool is_stable = PriorityQueueType::is_stable;
 
-private:
+protected:
     typedef std::pair<value_type, size_type> node_type;
 
 #ifdef BOOST_NO_CXX11_ALLOCATOR
@@ -122,7 +122,7 @@ public:
         friend class priority_queue_mutable_wrapper;
     };
 
-private:
+protected:
     struct indirect_cmp:
         public value_compare
     {
@@ -225,52 +225,61 @@ public:
 
     typedef typename object_list::difference_type difference_type;
 
-    class ordered_iterator:
-        public boost::iterator_adaptor<ordered_iterator,
+    template <typename Derived, typename Dispatcher, typename IndirectCmp, typename Wrapper>
+    class ordered_iterator_base:
+        public boost::iterator_adaptor<Derived,
                                        const_list_iterator,
                                        value_type const,
                                        boost::forward_traversal_tag
-                                      >,
-        q_type::ordered_iterator_dispatcher
+                                       >,
+        public Dispatcher
     {
-        typedef boost::iterator_adaptor<ordered_iterator,
+    protected:
+        typedef boost::iterator_adaptor<Derived,
                                         const_list_iterator,
                                         value_type const,
                                         boost::forward_traversal_tag
                                       > adaptor_type;
 
         typedef const_list_iterator iterator;
-        typedef typename q_type::ordered_iterator_dispatcher ordered_iterator_dispatcher;
+        typedef Dispatcher iterator_dispatcher;
 
         friend class boost::iterator_core_access;
 
     public:
-        ordered_iterator(void):
-            adaptor_type(0), unvisited_nodes(indirect_cmp()), q_(NULL)
+        ordered_iterator_base(void):
+            adaptor_type(0), unvisited_nodes(IndirectCmp()), q_(NULL)
         {}
 
-        ordered_iterator(const priority_queue_mutable_wrapper * q, indirect_cmp const & cmp):
+        ordered_iterator_base(const Wrapper * q, IndirectCmp const & cmp):
             adaptor_type(0), unvisited_nodes(cmp), q_(q)
         {}
 
-        ordered_iterator(const_list_iterator it, const priority_queue_mutable_wrapper * q, indirect_cmp const & cmp):
+        ordered_iterator_base(const_list_iterator it, const Wrapper * q, IndirectCmp const & cmp):
             adaptor_type(it), unvisited_nodes(cmp), q_(q)
         {
             if (it != q->objects.end())
-                discover_nodes(it);
+                static_cast<Derived *>(this)->discover_nodes(it);
         }
 
-        bool operator!=(ordered_iterator const & rhs) const
+        ordered_iterator_base(const_list_iterator it, const Wrapper * q, IndirectCmp const & cmp, Dispatcher const & dispatcher):
+            adaptor_type(it), Dispatcher(dispatcher), unvisited_nodes(cmp), q_(q)
+        {
+            if (it != q->objects.end())
+                static_cast<Derived *>(this)->discover_nodes(it);
+        }
+
+        bool operator!=(ordered_iterator_base const & rhs) const
         {
             return adaptor_type::base() != rhs.base();
         }
 
-        bool operator==(ordered_iterator const & rhs) const
+        bool operator==(ordered_iterator_base const & rhs) const
         {
             return !operator!=(rhs);
         }
 
-    private:
+    protected:
         void increment(void)
         {
             if (unvisited_nodes.empty())
@@ -278,7 +287,7 @@ public:
             else {
                 iterator next = unvisited_nodes.top();
                 unvisited_nodes.pop();
-                discover_nodes(next);
+                static_cast<Derived *>(this)->discover_nodes(next);
                 adaptor_type::base_reference() = next;
             }
         }
@@ -287,34 +296,60 @@ public:
         {
             return adaptor_type::base()->first;
         }
-
-        void discover_nodes(iterator current)
-        {
-            size_type current_index = current->second;
-            const q_type * q = &(q_->q_);
-
-            if (ordered_iterator_dispatcher::is_leaf(q, current_index))
-                return;
-
-            std::pair<size_type, size_type> child_range = ordered_iterator_dispatcher::get_child_nodes(q, current_index);
-
-            for (size_type i = child_range.first; i <= child_range.second; ++i) {
-                typename q_type::internal_type const & internal_value_at_index = ordered_iterator_dispatcher::get_internal_value(q, i);
-                typename q_type::value_type const & value_at_index = q_->q_.get_value(internal_value_at_index);
-
-                unvisited_nodes.push(value_at_index);
-            }
-        }
-
+   
         std::priority_queue<iterator,
 #ifdef BOOST_NO_CXX11_ALLOCATOR
                             std::vector<iterator, typename allocator_type::template rebind<iterator>::other >,
 #else
                             std::vector<iterator, typename std::allocator_traits<allocator_type>::template rebind_alloc<iterator> >,
 #endif
-                            indirect_cmp
+                            IndirectCmp
                            > unvisited_nodes;
-        const priority_queue_mutable_wrapper * q_;
+        const Wrapper * q_;
+    };
+
+    class ordered_iterator : public ordered_iterator_base<ordered_iterator,
+                                                          typename q_type::ordered_iterator_dispatcher,
+                                                          indirect_cmp,
+                                                          priority_queue_mutable_wrapper
+                                                          >
+    {
+        typedef ordered_iterator_base<ordered_iterator,
+                                      typename q_type::ordered_iterator_dispatcher,
+                                      indirect_cmp,
+                                      priority_queue_mutable_wrapper
+                                      > super_t;
+        
+    public:
+        ordered_iterator(void):
+            super_t()
+        {}
+
+        ordered_iterator(const priority_queue_mutable_wrapper * q, indirect_cmp const & cmp):
+            super_t(q, cmp)
+        {}
+
+        ordered_iterator(const_list_iterator it, const priority_queue_mutable_wrapper * q, indirect_cmp const & cmp):
+            super_t(it, q, cmp)
+        {}
+
+        void discover_nodes(typename super_t::iterator current)
+        {
+            size_type current_index = current->second;
+            const q_type * q = &(super_t::q_->q_);
+
+            if (super_t::iterator_dispatcher::is_leaf(q, current_index))
+                return;
+
+            std::pair<size_type, size_type> child_range = super_t::iterator_dispatcher::get_child_nodes(q, current_index);
+
+            for (size_type i = child_range.first; i <= child_range.second; ++i) {
+                typename q_type::internal_type const & internal_value_at_index = super_t::iterator_dispatcher::get_internal_value(q, i);
+                typename q_type::value_type const & value_at_index = super_t::q_->q_.get_value(internal_value_at_index);
+
+                super_t::unvisited_nodes.push(value_at_index);
+            }
+        }
     };
 
     bool empty(void) const
@@ -531,6 +566,255 @@ public:
     }
 };
 
+template <typename PriorityQueueType>
+class double_ended_priority_queue_mutable_wrapper:
+    public priority_queue_mutable_wrapper<PriorityQueueType>
+{
+    typedef priority_queue_mutable_wrapper<PriorityQueueType> super_t;
+
+    struct indirect_reverse_cmp:
+        public super_t::value_compare
+    {
+        indirect_reverse_cmp(typename super_t::value_compare const & cmp = super_t::value_compare()):
+            super_t::value_compare(cmp)
+        {}
+
+        bool operator()(typename super_t::const_list_iterator const & lhs, typename super_t::const_list_iterator const & rhs) const
+        {
+            return super_t::value_compare::operator()(rhs->first, lhs->first);
+        }
+    };
+    
+public:
+    double_ended_priority_queue_mutable_wrapper(typename super_t::value_compare const & cmp = super_t::value_compare()):
+        super_t(cmp)
+    {}
+
+    double_ended_priority_queue_mutable_wrapper(double_ended_priority_queue_mutable_wrapper const & rhs):
+        super_t(rhs)
+    {}
+
+    double_ended_priority_queue_mutable_wrapper & operator=(double_ended_priority_queue_mutable_wrapper const & rhs)
+    {
+        super_t::operator=(rhs);
+        return *this;
+    }
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+    double_ended_priority_queue_mutable_wrapper (double_ended_priority_queue_mutable_wrapper && rhs):
+        super_t(std::move(rhs))
+    {}
+
+    double_ended_priority_queue_mutable_wrapper & operator=(double_ended_priority_queue_mutable_wrapper && rhs)
+    {
+        super_t::operator=(std::move(rhs));
+        return *this;
+    }
+#endif
+
+public:
+    typename super_t::const_reference min(void) const
+    {
+        BOOST_ASSERT(!super_t::empty());
+        return super_t::q_.min()->first;
+    }
+
+    typename super_t::const_reference max(void) const
+    {
+        BOOST_ASSERT(!super_t::empty());
+        return super_t::q_.max()->first;
+    }
+
+    void pop_min(void)
+    {
+        BOOST_ASSERT(!super_t::empty());
+        typename super_t::list_iterator q_top = super_t::q_.min();
+        super_t::q_.pop_min();
+        super_t::objects.erase(q_top);
+    }
+
+    void pop_max(void)
+    {
+        BOOST_ASSERT(!super_t::empty());
+        typename super_t::list_iterator q_top = super_t::q_.max();
+        super_t::q_.pop_max();
+        super_t::objects.erase(q_top);
+    }
+
+public:
+    template <typename Derived,
+              typename Dispatcher,
+              typename IndirectCmp
+              >
+    class ordered_iterator_base :
+        public super_t::template ordered_iterator_base<Derived,
+                                                       Dispatcher,
+                                                       IndirectCmp,
+                                                       double_ended_priority_queue_mutable_wrapper
+                                                       >
+    {
+        typedef typename super_t::template ordered_iterator_base<Derived,
+                                                                 Dispatcher,
+                                                                 IndirectCmp,
+                                                                 double_ended_priority_queue_mutable_wrapper
+                                                                 > iterator_super_t;
+        
+    public:
+        ordered_iterator_base(void):
+            iterator_super_t()
+        {}
+
+        ordered_iterator_base(const double_ended_priority_queue_mutable_wrapper * q, IndirectCmp const & cmp):
+            iterator_super_t(q, cmp)
+        {}
+
+        ordered_iterator_base(typename super_t::const_list_iterator it, const double_ended_priority_queue_mutable_wrapper * q, indirect_reverse_cmp const & cmp):
+            iterator_super_t(it, q, cmp)
+        {}
+
+        ordered_iterator_base(typename super_t::const_list_iterator it, const double_ended_priority_queue_mutable_wrapper * q, indirect_reverse_cmp const & cmp, typename iterator_super_t::iterator_dispatcher const & dispatcher):
+            iterator_super_t(it, q, cmp, dispatcher)
+        {}
+        
+        void discover_nodes(typename iterator_super_t::iterator current)
+        {
+            typedef typename super_t::size_type size_type;
+            typedef typename super_t::q_type q_type;
+            
+            size_type current_index = current->second;
+            const q_type * q = &(iterator_super_t::q_->q_);
+
+            if (iterator_super_t::iterator_dispatcher::is_leaf(q, current_index))
+                return;
+
+            std::pair<size_type, size_type> extra_child_range = std::make_pair(1, 0);
+            std::pair<size_type, size_type> child_range = iterator_super_t::iterator_dispatcher::get_child_nodes(q, current_index, extra_child_range);
+
+            for (size_type i = extra_child_range.first; i <= extra_child_range.second; ++i) {
+                typename q_type::internal_type const & internal_value_at_index = iterator_super_t::iterator_dispatcher::get_internal_value(q, i);
+                typename q_type::value_type const & value_at_index = iterator_super_t::q_->q_.get_value(internal_value_at_index);
+
+                iterator_super_t::unvisited_nodes.push(value_at_index);
+            }
+            
+            for (size_type i = child_range.first; i <= child_range.second; ++i) {
+                typename q_type::internal_type const & internal_value_at_index = iterator_super_t::iterator_dispatcher::get_internal_value(q, i);
+                typename q_type::value_type const & value_at_index = iterator_super_t::q_->q_.get_value(internal_value_at_index);
+
+                iterator_super_t::unvisited_nodes.push(value_at_index);
+            }
+        }
+    };
+
+public:
+    class ordered_iterator : public ordered_iterator_base<ordered_iterator,
+                                                          typename super_t::q_type::ordered_iterator_dispatcher,
+                                                          typename super_t::indirect_cmp
+                                                          >
+    {
+        typedef ordered_iterator_base<ordered_iterator,
+                                      typename super_t::q_type::ordered_iterator_dispatcher,
+                                      typename super_t::indirect_cmp
+                                      >
+        iterator_base_super_t;
+
+    public:
+        ordered_iterator(void):
+            iterator_base_super_t()
+        {}
+
+        ordered_iterator(const double_ended_priority_queue_mutable_wrapper * q, typename super_t::indirect_cmp const & cmp):
+            iterator_base_super_t(q, cmp)
+        {}
+
+        ordered_iterator(typename super_t::const_list_iterator it, const double_ended_priority_queue_mutable_wrapper * q, typename super_t::indirect_cmp const & cmp):
+            iterator_base_super_t(it, q, cmp)
+        {}
+
+        ordered_iterator(typename super_t::const_list_iterator it, const double_ended_priority_queue_mutable_wrapper * q, typename super_t::indirect_cmp const & cmp, typename iterator_base_super_t::iterator_dispatcher const & dispatcher):
+            iterator_base_super_t(it, q, cmp, dispatcher)
+        {}
+    };
+    
+    ordered_iterator ordered_begin(void) const
+    {
+        if (!super_t::empty())
+            return ordered_iterator(super_t::q_.min(), this, typename super_t::indirect_cmp(super_t::q_.value_comp()), typename super_t::q_type::ordered_iterator_dispatcher(super_t::q_.size()));
+        else
+            return ordered_end();
+    }
+
+    ordered_iterator ordered_end(void) const
+    {
+        return ordered_iterator(super_t::objects.end(), this, typename super_t::indirect_cmp(super_t::q_.value_comp()), typename super_t::q_type::ordered_iterator_dispatcher(0));
+    }
+
+public:
+    class reverse_ordered_iterator : public ordered_iterator_base<reverse_ordered_iterator,
+                                                                  typename super_t::q_type::reverse_ordered_iterator_dispatcher,
+                                                                  indirect_reverse_cmp
+                                                                  >
+    {
+        typedef ordered_iterator_base<reverse_ordered_iterator,
+                                      typename super_t::q_type::reverse_ordered_iterator_dispatcher,
+                                      indirect_reverse_cmp>
+        iterator_base_super_t;
+
+    public:
+        reverse_ordered_iterator(void):
+            iterator_base_super_t()
+        {}
+
+        reverse_ordered_iterator(const double_ended_priority_queue_mutable_wrapper * q, indirect_reverse_cmp const & cmp):
+            iterator_base_super_t(q, cmp)
+        {}
+
+        reverse_ordered_iterator(typename super_t::const_list_iterator it, const double_ended_priority_queue_mutable_wrapper * q, indirect_reverse_cmp const & cmp):
+            iterator_base_super_t(it, q, cmp)
+        {}
+
+        reverse_ordered_iterator(typename super_t::const_list_iterator it, const double_ended_priority_queue_mutable_wrapper * q, indirect_reverse_cmp const & cmp, typename iterator_base_super_t::iterator_dispatcher const & dispatcher):
+            iterator_base_super_t(it, q, cmp, dispatcher)
+        {}
+
+                reverse_ordered_iterator(typename super_t::const_list_iterator it, std::pair<typename super_t::size_type, typename super_t::size_type> initial_indexes, const double_ended_priority_queue_mutable_wrapper * q, indirect_reverse_cmp const & cmp, typename iterator_base_super_t::iterator_dispatcher const & dispatcher):
+            iterator_base_super_t(it, q, cmp, dispatcher)
+        {
+            const typename super_t::q_type * q_ = &(iterator_base_super_t::q_->q_);
+            
+            for (size_t i = initial_indexes.first; i <= initial_indexes.second; ++i)
+                if (i != it->second) {
+                    typename super_t::q_type::internal_type const & internal_value_at_index = iterator_base_super_t::iterator_dispatcher::get_internal_value(q_, i);
+                    typename super_t::q_type::value_type const & value_at_index = iterator_base_super_t::q_->q_.get_value(internal_value_at_index);
+                
+                    iterator_base_super_t::unvisited_nodes.push(value_at_index);
+                }
+        }
+    };
+    
+    reverse_ordered_iterator reverse_ordered_begin(void) const
+    {
+        if (!super_t::empty()) {
+            if (1 < super_t::size()) {
+                typename super_t::const_list_iterator it = super_t::q_.max();
+                std::pair<typename super_t::size_type, typename super_t::size_type> initial_indexes;
+                initial_indexes.first = 1;
+                initial_indexes.second = std::min<typename super_t::size_type>(PriorityQueueType::D, super_t::size());
+                
+                return reverse_ordered_iterator(it, initial_indexes, this, indirect_reverse_cmp(super_t::q_.value_comp()), typename super_t::q_type::reverse_ordered_iterator_dispatcher(super_t::q_.size()));
+            }
+            else
+                return reverse_ordered_iterator(super_t::q_.max(), this, indirect_reverse_cmp(super_t::q_.value_comp()), typename super_t::q_type::reverse_ordered_iterator_dispatcher(super_t::q_.size()));
+        }
+        else
+            return reverse_ordered_end();
+    }
+
+    reverse_ordered_iterator reverse_ordered_end(void) const
+    {
+        return reverse_ordered_iterator(super_t::objects.end(), this, indirect_reverse_cmp(super_t::q_.value_comp()), typename super_t::q_type::reverse_ordered_iterator_dispatcher(super_t::q_.size()));
+    }
+};    
 
 } /* namespace detail */
 } /* namespace heap */

--- a/include/boost/heap/detail/ordered_adaptor_iterator.hpp
+++ b/include/boost/heap/detail/ordered_adaptor_iterator.hpp
@@ -43,7 +43,7 @@ template <typename Derived,
           typename ValueCompare,
           typename Dispatcher
           >
-class ordered_adaptor_iterator_base :
+class ordered_adaptor_iterator_facade :
         public boost::iterator_facade<Derived,
                                       ValueType,
                                       boost::forward_traversal_tag
@@ -75,24 +75,24 @@ public:
     size_t current_index; // current index: special value -1 denotes `end' iterator
 
 public:
-    ordered_adaptor_iterator_base(void):
+    ordered_adaptor_iterator_facade(void):
         container(NULL), current_index((std::numeric_limits<size_t>::max)()),
         unvisited_nodes(compare_by_heap_value(NULL, ValueCompare()))
     {}
 
-    ordered_adaptor_iterator_base(const ContainerType * container, ValueCompare const & cmp):
+    ordered_adaptor_iterator_facade(const ContainerType * container, ValueCompare const & cmp):
         container(container), current_index(container->size()),
         unvisited_nodes(compare_by_heap_value(container, ValueCompare()))
     {}
 
-    ordered_adaptor_iterator_base(size_t initial_index, const ContainerType * container, ValueCompare const & cmp):
+    ordered_adaptor_iterator_facade(size_t initial_index, const ContainerType * container, ValueCompare const & cmp):
         container(container), current_index(initial_index),
         unvisited_nodes(compare_by_heap_value(container, cmp))
     {
         static_cast<Derived *>(this)->discover_nodes(initial_index);
     }
 
-    ordered_adaptor_iterator_base(size_t initial_index, const ContainerType * container, ValueCompare const & cmp, const Dispatcher & dispatcher):
+    ordered_adaptor_iterator_facade(size_t initial_index, const ContainerType * container, ValueCompare const & cmp, const Dispatcher & dispatcher):
         Dispatcher(dispatcher),
         container(container), current_index(initial_index),
         unvisited_nodes(compare_by_heap_value(container, cmp))
@@ -101,7 +101,7 @@ public:
     }
 
 public:
-    bool equal (ordered_adaptor_iterator_base const & rhs) const
+    bool equal (ordered_adaptor_iterator_facade const & rhs) const
     {
         if (current_index != rhs.current_index)
             return false;
@@ -148,30 +148,30 @@ template <typename ValueType,
           typename Dispatcher
          >
 class ordered_adaptor_iterator:
-        public ordered_adaptor_iterator_base<ordered_adaptor_iterator<ValueType,
-                                                                      InternalType,
-                                                                      ContainerType,
-                                                                      Alloc,
-                                                                      ValueCompare,
-                                                                      Dispatcher>,
-                                             ValueType,
-                                             ContainerType,
-                                             Alloc,
-                                             ValueCompare,
-                                             Dispatcher>
+        public ordered_adaptor_iterator_facade<ordered_adaptor_iterator<ValueType,
+                                                                        InternalType,
+                                                                        ContainerType,
+                                                                        Alloc,
+                                                                        ValueCompare,
+                                                                        Dispatcher>,
+                                               ValueType,
+                                               ContainerType,
+                                               Alloc,
+                                               ValueCompare,
+                                               Dispatcher>
 {
-    typedef ordered_adaptor_iterator_base<ordered_adaptor_iterator<ValueType,
-                                                                   InternalType,
-                                                                   ContainerType,
-                                                                   Alloc,
-                                                                   ValueCompare,
-                                                                   Dispatcher>,
-                                          ValueType,
-                                          ContainerType,
-                                          Alloc,
-                                          ValueCompare,
-                                          Dispatcher>
-    base;
+    typedef ordered_adaptor_iterator_facade<ordered_adaptor_iterator<ValueType,
+                                                                     InternalType,
+                                                                     ContainerType,
+                                                                     Alloc,
+                                                                     ValueCompare,
+                                                                     Dispatcher>,
+                                            ValueType,
+                                            ContainerType,
+                                            Alloc,
+                                            ValueCompare,
+                                            Dispatcher>
+    facade;
 
     friend class boost::iterator_core_access;
 
@@ -180,27 +180,27 @@ public:
     {}
 
     ordered_adaptor_iterator(const ContainerType * container, ValueCompare const & cmp):
-        base(container, cmp)
+        facade(container, cmp)
     {}
 
     ordered_adaptor_iterator(size_t initial_index, const ContainerType * container, ValueCompare const & cmp):
-        base(initial_index, container, cmp)
+        facade(initial_index, container, cmp)
     {}
 
     ordered_adaptor_iterator(size_t initial_index, const ContainerType * container, ValueCompare const & cmp, const Dispatcher & dispatcher):
-        base(initial_index, container, cmp, dispatcher)
+        facade(initial_index, container, cmp, dispatcher)
     {}
 
 public:
     void discover_nodes(size_t index)
     {
-        if (Dispatcher::is_leaf(base::container, index))
+        if (Dispatcher::is_leaf(facade::container, index))
             return;
 
-        std::pair<size_t, size_t> child_range = Dispatcher::get_child_nodes(base::container, index);
+        std::pair<size_t, size_t> child_range = Dispatcher::get_child_nodes(facade::container, index);
 
         for (size_t i = child_range.first; i <= child_range.second; ++i)
-            base::unvisited_nodes.push(i);
+            facade::unvisited_nodes.push(i);
     }
 };
 
@@ -212,32 +212,32 @@ template <typename ValueType,
           typename Dispatcher
          >
 class extended_ordered_adaptor_iterator:
-        public ordered_adaptor_iterator_base<extended_ordered_adaptor_iterator<ValueType,
-                                                                               InternalType,
-                                                                               ContainerType,
-                                                                               Alloc,
-                                                                               ValueCompare,
-                                                                               Dispatcher>,
-                                             ValueType,
-                                             ContainerType,
-                                             Alloc,
-                                             ValueCompare,
-                                             Dispatcher
-                                             >
+        public ordered_adaptor_iterator_facade<extended_ordered_adaptor_iterator<ValueType,
+                                                                                 InternalType,
+                                                                                 ContainerType,
+                                                                                 Alloc,
+                                                                                 ValueCompare,
+                                                                                 Dispatcher>,
+                                               ValueType,
+                                               ContainerType,
+                                               Alloc,
+                                               ValueCompare,
+                                               Dispatcher
+                                               >
 {
-    typedef ordered_adaptor_iterator_base<extended_ordered_adaptor_iterator<ValueType,
-                                                                            InternalType,
-                                                                            ContainerType,
-                                                                            Alloc,
-                                                                            ValueCompare,
-                                                                            Dispatcher>,
-                                          ValueType,
-                                          ContainerType,
-                                          Alloc,
-                                          ValueCompare,
-                                          Dispatcher
-                                          >
-    base;
+    typedef ordered_adaptor_iterator_facade<extended_ordered_adaptor_iterator<ValueType,
+                                                                              InternalType,
+                                                                              ContainerType,
+                                                                              Alloc,
+                                                                              ValueCompare,
+                                                                              Dispatcher>,
+                                            ValueType,
+                                            ContainerType,
+                                            Alloc,
+                                            ValueCompare,
+                                            Dispatcher
+                                            >
+    facade;
 
     friend class boost::iterator_core_access;
 
@@ -245,39 +245,31 @@ public:
     extended_ordered_adaptor_iterator(void)
     {}
 
-    extended_ordered_adaptor_iterator(const ContainerType * container, ValueCompare const & cmp):
-        base(container, cmp)
-    {}
-
-    extended_ordered_adaptor_iterator(size_t initial_index, const ContainerType * container, ValueCompare const & cmp):
-        base(initial_index, container, cmp)
-    {}
-
     extended_ordered_adaptor_iterator(size_t initial_index, const ContainerType * container, ValueCompare const & cmp, const Dispatcher & dispatcher):
-        base(initial_index, container, cmp, dispatcher)
+        facade(initial_index, container, cmp, dispatcher)
     {}
 
     extended_ordered_adaptor_iterator(size_t initial_index, std::pair<size_t, size_t> initial_indexes, const ContainerType * container, ValueCompare const & cmp, const Dispatcher & dispatcher):
-        base(initial_index, container, cmp, dispatcher)
+        facade(initial_index, container, cmp, dispatcher)
     {
         for (size_t i = initial_indexes.first; i <= initial_indexes.second; ++i)
             if (i != initial_index)
-                base::unvisited_nodes.push(i);
+                facade::unvisited_nodes.push(i);
     }
 
     void discover_nodes(size_t index)
     {
-        if (Dispatcher::is_leaf(base::container, index))
+        if (Dispatcher::is_leaf(facade::container, index))
             return;
 
         std::pair<size_t, size_t> extra_child_range = std::make_pair(1, 0);
-        std::pair<size_t, size_t> child_range = Dispatcher::get_child_nodes(base::container, index, extra_child_range);
+        std::pair<size_t, size_t> child_range = Dispatcher::get_child_nodes(facade::container, index, extra_child_range);
 
         for (size_t i = extra_child_range.first; i <= extra_child_range.second; ++i)
-            base::unvisited_nodes.push(i);
+            facade::unvisited_nodes.push(i);
 
         for (size_t i = child_range.first; i <= child_range.second; ++i)
-            base::unvisited_nodes.push(i);
+            facade::unvisited_nodes.push(i);
     }
 };
 

--- a/include/boost/heap/detail/ordered_adaptor_iterator.hpp
+++ b/include/boost/heap/detail/ordered_adaptor_iterator.hpp
@@ -31,6 +31,10 @@ namespace detail {
  * * static internal_type const & get_internal_value(const ContainerType * heap, size_type index); // get internal value at index
  * * static value_type const & get_value(internal_type const & arg) const; // get value_type from internal_type
  *
+ * Requirements for Derived:
+ *
+ * * void discover_nodes(size_t index); // return children
+ *
  * */
 template <typename Derived,
           typename ValueType,
@@ -252,6 +256,14 @@ public:
     extended_ordered_adaptor_iterator(size_t initial_index, const ContainerType * container, ValueCompare const & cmp, const Dispatcher & dispatcher):
         base(initial_index, container, cmp, dispatcher)
     {}
+
+    extended_ordered_adaptor_iterator(size_t initial_index, std::pair<size_t, size_t> initial_indexes, const ContainerType * container, ValueCompare const & cmp, const Dispatcher & dispatcher):
+        base(initial_index, container, cmp, dispatcher)
+    {
+        for (size_t i = initial_indexes.first; i <= initial_indexes.second; ++i)
+            if (i != initial_index)
+                base::unvisited_nodes.push(i);
+    }
 
     void discover_nodes(size_t index)
     {

--- a/include/boost/heap/detail/ordered_adaptor_iterator.hpp
+++ b/include/boost/heap/detail/ordered_adaptor_iterator.hpp
@@ -92,6 +92,14 @@ public:
         discover_nodes(initial_index);
     }
 
+    ordered_adaptor_iterator(size_t initial_index, const ContainerType * container, ValueCompare const & cmp, const Dispatcher & dispatcher):
+        Dispatcher(dispatcher),
+        container(container), current_index(initial_index),
+        unvisited_nodes(compare_by_heap_value(container, cmp))
+    {
+        discover_nodes(initial_index);
+    }
+
 private:
     bool equal (ordered_adaptor_iterator const & rhs) const
     {

--- a/include/boost/heap/min_max_heap.hpp
+++ b/include/boost/heap/min_max_heap.hpp
@@ -1,0 +1,1161 @@
+// // boost heap: min-max heap
+//
+// The majority of this file comes from d_ary_heap.hpp
+// Copyright (C) 2010 Tim Blechmann
+//
+// The parts related to the implementation of the min-max heap
+// are however new.
+// Copyright (C) 2019 Grégoire Scano
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+/* Implementation of
+   @article{Atkinson:1986:MHG:6617.6621,
+   author = {Atkinson, M. D. and Sack, J.-R. and Santoro, N. and Strothotte, T.},
+   title = {Min-max Heaps and Generalized Priority Queues},
+   journal = {Commun. ACM},
+   issue_date = {Oct. 1986},
+   volume = {29},
+   number = {10},
+   month = {oct},
+   year = {1986},
+   issn = {0001-0782},
+   pages = {996--1000},
+   numpages = {5},
+   url = {http://doi.acm.org/10.1145/6617.6621},
+   doi = {http://dx.doi.org/10.1145/6617.6621},
+   acmid = {6621},
+   publisher = {ACM},
+   address = {New York, NY, USA}
+   }
+*/
+
+#ifndef BOOST_HEAP_MIN_MAX_HEAP_HPP
+#define BOOST_HEAP_MIN_MAX_HEAP_HPP
+
+#include <vector>
+#include <cmath>
+
+#include <boost/heap/policies.hpp>
+
+#include <boost/heap/detail/heap_comparison.hpp>
+#include <boost/heap/detail/ilog2.hpp>
+#include <boost/heap/detail/mutable_heap.hpp>
+#include <boost/heap/detail/ordered_adaptor_iterator.hpp>
+#include <boost/heap/detail/stable_heap.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+#ifndef BOOST_DOXYGEN_INVOKED
+#ifdef BOOST_HEAP_SANITYCHECKS
+#define BOOST_HEAP_ASSERT BOOST_ASSERT
+#else
+#define BOOST_HEAP_ASSERT(expression)
+#endif
+#endif
+
+namespace boost  {
+namespace heap   {
+namespace detail {
+
+template<unsigned int Base, typename IntType>
+struct tree_depth;
+
+typedef parameter::parameters<boost::parameter::optional<tag::arity>,
+                              boost::parameter::optional<tag::allocator>,
+                              boost::parameter::optional<tag::compare>,
+                              boost::parameter::optional<tag::stable>,
+                              boost::parameter::optional<tag::stability_counter_type>
+                              > min_max_heap_signature;
+
+/* base class for min-max heap */
+template <typename T,
+          class BoundArgs,
+          class IndexUpdater>
+class min_max_heap:
+    private make_heap_base<T, BoundArgs, false>::type
+{
+    typedef make_heap_base<T, BoundArgs, false> heap_base_maker;
+
+    typedef typename heap_base_maker::type super_t;
+    typedef typename super_t::internal_type internal_type;
+
+    typedef IndexUpdater index_updater;
+
+#ifdef BOOST_NO_CXX11_ALLOCATOR
+    typedef typename heap_base_maker::allocator_argument::template rebind<internal_type>::other internal_type_allocator;
+#else
+    typedef typename std::allocator_traits<typename heap_base_maker::allocator_argument>::template rebind_alloc<internal_type> internal_type_allocator;
+#endif
+    typedef std::vector<internal_type, internal_type_allocator> container_type;
+
+    container_type q_;
+
+    static const unsigned int D = parameter::binding<BoundArgs, tag::arity, mpl::int_<2> >::type::value;
+
+    template <typename Heap1, typename Heap2>
+    friend struct heap_merge_emulate;
+
+public:
+    typedef T value_type;
+
+    struct implementation_defined: extract_allocator_types<typename heap_base_maker::allocator_argument>
+    {};
+
+    typedef typename implementation_defined::size_type size_type;
+    typedef typename implementation_defined::difference_type difference_type;
+    typedef typename implementation_defined::reference reference;
+    typedef typename implementation_defined::const_reference const_reference;
+    typedef typename implementation_defined::pointer pointer;
+    typedef typename implementation_defined::const_pointer const_pointer;
+
+    typedef typename heap_base_maker::compare_argument value_compare;
+    typedef typename heap_base_maker::allocator_argument allocator_type;
+
+    typedef void * handle_type;
+
+    static const bool is_stable = extract_stable<BoundArgs>::value;
+
+    /* xtors */
+public:
+    explicit min_max_heap(const value_compare & cmp = value_compare()) :
+        super_t(cmp)
+    {}
+
+    min_max_heap(const min_max_heap & rhs) :
+        super_t(rhs), q_(rhs.q_)
+    {}
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+    min_max_heap(min_max_heap && rhs) :
+        super_t(std::move(rhs)), q_(std::move(rhs.q_))
+    {}
+
+    min_max_heap & operator = (min_max_heap && rhs)
+    {
+        super_t::operator = (std::move(rhs));
+        q_ = std::move(rhs.q_);
+        return *this;
+    }
+#endif
+
+    min_max_heap & operator = (min_max_heap const & rhs)
+    {
+        static_cast<super_t &>(*this) = static_cast<super_t const &>(rhs);
+        q_ = rhs.q_;
+        return *this;
+    }
+
+    void swap(min_max_heap & rhs)
+    {
+        super_t::swap(rhs);
+        std::swap(q_, rhs.q_);
+    }
+    /* xtors */
+
+    /* allocator */
+    allocator_type get_allocator(void) const
+    {
+        return q_.get_allocator();
+    }
+    /* allocator */
+
+    /* compare */
+    value_compare const & value_comp(void) const
+    {
+        return super_t::value_comp();
+    }
+
+    template<bool Regular>
+    bool compare(size_type i, size_type j) const
+    {
+        BOOST_ASSERT(i < this->size());
+        BOOST_ASSERT(j < this->size());
+        // use > or std::greater for min-max heap
+        // use < or std::less for a max-min heap
+        if (!Regular)
+            return super_t::operator () (q_[i], q_[j]);
+        else
+            return super_t::operator () (q_[j], q_[i]);
+    }
+    /* compare */
+
+    /* container */
+    bool empty(void) const
+    {
+        return q_.empty();
+    }
+
+    size_type size(void) const
+    {
+        return q_.size();
+    }
+
+    size_type max_size(void) const
+    {
+        return q_.max_size();
+    }
+
+    void reserve(size_t size)
+    {
+        q_.reserve(size);
+    }
+
+    void clear(void)
+    {
+        q_.clear();
+    }
+    /* container */
+
+    /* indexes */
+    void reset_index(size_type index, size_type new_index)
+    {
+        BOOST_HEAP_ASSERT(index < q_.size());
+        index_updater::run(q_[index], new_index);
+    }
+
+    bool is_on_compare_level(size_type index) const
+    {
+        tree_depth<D, size_type> depth;
+        return !(depth(index) % 2);
+    }
+
+    size_type root(void) const
+    {
+        return 0;
+    }
+
+    std::pair<size_type, size_type> get_child_nodes(size_type index) const
+    {
+        return std::make_pair(first_child(index), last_child(index));
+    }
+
+    size_type first_child(size_type index) const
+    {
+        return D * index + 1;
+    }
+
+    size_type last_child(size_type index) const
+    {
+        return D * (index + 1);
+    }
+
+    std::pair<size_type, size_type> get_grandchild_nodes(size_type index) const
+    {
+        return std::make_pair(first_grandchild(index), last_grandchild(index));
+    }
+
+    size_type first_grandchild(size_type index) const
+    {
+        return first_child(first_child(index));
+    }
+
+    size_type last_grandchild(size_type index) const
+    {
+        return last_child(last_child(index));
+    }
+
+    size_type last(void) const
+    {
+        return q_.size() - 1;
+    }
+
+    size_type npos(void) const
+    {
+        return -1;
+    }
+
+    bool is_leaf(size_type index) const
+    {
+        return q_.size() <= first_child(index);
+    }
+
+    bool has_parent(size_type index) const
+    {
+        return index != root();
+    }
+
+    size_type parent(size_type index) const
+    {
+        if (index == root() || index == npos())
+            return npos();
+        else
+            return (index - 1) / D;
+    }
+
+    size_type grandparent(size_type index) const
+    {
+        return parent(parent(index));
+    }
+
+    template<bool Regular>
+    bool best_between(size_type & best, size_type current, size_type theorical_last) const
+    {
+        bool found = false;
+
+        for (const size_type last = std::min(theorical_last, this->last()); current <= last; ++current)
+            if (compare<Regular>(current, best)) {
+                best = current;
+                found = true;
+            }
+
+        return found;
+    }
+
+    template<bool Regular>
+    size_type best_child_or_grandchild(size_type index, bool & is_grandchild) const
+    {
+        const size_type first_child = this->first_child(index);
+
+        if(last() < first_child) return npos();
+
+        const size_type last_child = this->last_child(index);
+        const size_type first_grandchild = this->first_child(first_child);
+        const size_type last_grandchild = this->last_child(last_child);
+
+        size_type best_child = first_child;
+
+        best_between<Regular>(best_child, first_child + 1, last_child);
+        is_grandchild = best_between<Regular>(best_child, first_grandchild, last_grandchild);
+
+        return best_child;
+    }
+    /* indexes */
+
+    /* moves */
+    void trickle_down(size_type index)
+    {
+        if (is_on_compare_level(index))
+            trickle_down_impl<true>(index);
+        else
+            trickle_down_impl<false>(index);
+    }
+
+    template<bool Regular>
+    void trickle_down_impl(size_type i)
+    {
+        bool is_grandchild;
+        size_type m = best_child_or_grandchild<Regular>(i, is_grandchild);
+
+        if (m < npos()) {
+            if (is_grandchild) {
+                if (compare<Regular>(m, i)) {
+                    swap(i, m);
+
+                    size_type parent = this->parent(m);
+
+                    if (compare<Regular>(parent, m))
+                        swap(m, parent);
+
+                    trickle_down_impl<Regular>(m);
+                }
+            }
+            else
+                if (compare<Regular>(m, i))
+                    swap(i, m);
+        }
+    }
+
+    void bubble_up(size_type i)
+    {
+        if (is_on_compare_level(i))
+            bubble_up_impl<true>(i);
+        else
+            bubble_up_impl<false>(i);
+    }
+
+    template<bool Regular>
+    void bubble_up_impl(size_type i)
+    {
+        size_type parent = this->parent(i);
+
+        if (parent != npos()) {
+            if (compare<Regular>(parent, i)) {
+                swap(i, parent);
+                bubble_up_impl_<!Regular>(parent);
+            }
+            else
+                bubble_up_impl_<Regular>(i);
+        }
+    }
+
+    template<bool Regular>
+    void bubble_up_impl_(size_type i)
+    {
+        size_type grandparent = this->grandparent(i);
+
+        if(grandparent != npos()
+           && compare<Regular>(i, grandparent)) {
+            swap(i, grandparent);
+            bubble_up_impl_<Regular>(grandparent);
+        }
+    }
+    /* moves */
+
+    /* operations */
+    void swap(size_type i, size_type j)
+    {
+        BOOST_ASSERT(i < size());
+        BOOST_ASSERT(j < size());
+
+        reset_index(i, j);
+        reset_index(j, i);
+
+        std::swap(q_[i], q_[j]);
+    }
+
+protected:
+    size_type index_of_min(void) const
+    {
+        return root();
+    }
+
+    size_type index_of_max(void) const
+    {
+        size_type best = root();
+
+        best_between<false>(best, 1, D);
+
+        return best;
+    }
+    /* operations */
+
+    /* interface */
+    void push(const value_type & v)
+    {
+        q_.push_back(super_t::make_node(v));
+
+        size_type index = last();
+        reset_index(index, index);
+
+        bubble_up(index);
+    }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+    template <class... Args>
+    void emplace(Args&&... args)
+    {
+        q_.emplace_back(super_t::make_node(std::forward<Args>(args)...));
+        reset_index(last(), last());
+        bubble_up(last());
+    }
+#endif
+
+    value_type const & min(void) const
+    {
+        BOOST_ASSERT(!empty());
+
+        return super_t::get_value(q_[index_of_min()]);
+    }
+
+    value_type const & max(void) const
+    {
+        BOOST_ASSERT(!empty());
+
+        return super_t::get_value(q_[index_of_max()]);
+    }
+
+    void pop_min(void)
+    {
+        erase(index_of_min());
+    }
+
+    void pop_max(void)
+    {
+        erase(index_of_max());
+    }
+
+public:
+    void update(size_type index)
+    {
+        if(index == root())
+        {
+            return trickle_down(index);
+        }
+
+        size_type parent = parent(index);
+
+        if(compare(parent, index))
+        {
+            return decrease(index);
+        }
+
+        size_type grandparent = grandparent(index);
+
+        if(grandparent < last()
+           && compare(index, grandparent))
+        {
+            return increase(index);
+        }
+    }
+
+    void increase(size_type index)
+    {
+        if(index == root()
+           || !is_on_compare_level(index))
+        {
+            trickle_down(index);
+        }
+        else
+        {
+            size_type parent = parent(index);
+
+            if(compare(parent, index))
+            {
+                trickle_down(index);
+            }
+
+            bubble_up(index);
+        }
+    }
+
+    void decrease(size_type index)
+    {
+        if(is_on_compare_level(index))
+        {
+            bubble_up(index);
+        }
+        else
+        {
+            size_type parent = parent(index);
+
+            if(compare(parent, index))
+            {
+                bubble_up(index);
+            }
+
+            trickle_down(index);
+        }
+    }
+
+    void erase(size_type index)
+    {
+        BOOST_ASSERT(!empty());
+        BOOST_ASSERT(index < size());
+
+        swap(index, last());//TODO last()
+        q_.pop_back();
+
+        if(!empty() && index != size())
+        {
+            trickle_down(index);
+        }
+    }
+    /* interface */
+
+    /* iterators */
+public:
+    typedef detail::stable_heap_iterator<const value_type, typename container_type::const_iterator, super_t> iterator;
+    typedef iterator const_iterator;
+
+public:
+    iterator begin(void)
+    {
+      return iterator(q_.begin());
+    }
+
+    iterator end(void)
+    {
+      return iterator(q_.end());
+    }
+
+    const_iterator begin(void) const
+    {
+        return const_iterator(q_.begin());
+    }
+
+    const_iterator end(void) const
+    {
+      return const_iterator(q_.end());
+    }
+
+public:
+    template<class Order>
+    struct iterator_dispatcher
+    {
+        static size_type max_index(const min_max_heap * heap)
+        {
+            return heap->last();
+        }
+
+        bool is_leaf(const min_max_heap * heap, size_type index) const
+        {
+            return false;
+        }
+
+        std::pair<size_type, size_type> get_child_nodes(const min_max_heap * heap, size_type index)
+        {
+            return std::make_pair(1, 0);
+        }
+
+        static internal_type const & get_internal_value(const min_max_heap * heap, size_type index)
+        {
+            return heap->q_[index];
+        }
+
+        static value_type const & get_value(internal_type const & arg)
+        {
+            return super_t::get_value(arg);
+        }
+    };
+
+public:
+    struct ordered_iterator_dispatcher : iterator_dispatcher<ordered_iterator_dispatcher>
+    {
+
+    };
+
+public:
+    typedef detail::ordered_adaptor_iterator<const value_type,
+                                             internal_type,
+                                             min_max_heap,
+                                             allocator_type,
+                                             typename super_t::internal_compare,
+                                             ordered_iterator_dispatcher>
+    ordered_iterator;
+
+public:
+    ordered_iterator ordered_begin(void) const
+    {
+        return ordered_iterator(root(), this, super_t::get_internal_cmp());
+    }
+
+    ordered_iterator ordered_end(void) const
+    {
+        return ordered_iterator(q_.size(), this, super_t::get_internal_cmp());
+    }
+
+public:
+    struct reverse_ordered_iterator_dispatcher : iterator_dispatcher<reverse_ordered_iterator_dispatcher>
+    {
+
+    };
+
+public:
+    struct reverse_internal_compare : super_t::internal_compare
+    {
+        reverse_internal_compare(value_compare const & cmp = value_compare()) :
+            super_t::internal_compare(cmp)
+        {}
+
+        bool operator () (typename super_t::internal_type const & lhs, typename super_t::internal_type const & rhs) const
+        {
+            return super_t::internal_compare(rhs, lhs);
+        }
+      };
+
+    typedef detail::ordered_adaptor_iterator<const value_type,
+                                             internal_type,
+                                             min_max_heap,
+                                             allocator_type,
+                                             reverse_internal_compare,
+                                             reverse_ordered_iterator_dispatcher>
+    reverse_ordered_iterator;
+
+public:
+    reverse_ordered_iterator reverse_ordered_begin(void) const
+    {
+        return revese_ordered_iterator(root(), this, super_t::get_internal_cmp());
+    }
+
+    reverse_ordered_iterator reverse_ordered_end(void) const
+    {
+        return revese_ordered_iterator(q_.size(), this, super_t::get_internal_cmp());
+    }
+    /* iterators */
+};
+
+template<unsigned int Base, typename IntType>
+struct tree_depth
+{
+    IntType operator () (IntType index) const
+    {
+        IntType power = Base;
+        IntType count = 1;
+        IntType depth = 0;
+
+        while (count <= index) {
+            count += power;
+            power *= Base;
+            ++depth;
+        }
+
+        return depth;
+    }
+
+    /* Alternatively, let f be a function mapping an index n to its
+       corresponding depth (or row) r in a D tree, f_D(n)=r and 1 < D
+       If n is on row r, then $\sum_{i=0}^{r} D^{i} <= n < \sum_{i=0}^{r+1} D^{i}$
+       hence $D^{r+1} <= (D-1) * n + 1 < D^{r+2}$ then
+       $r + 1 <= \frac{log_2((D-1) * n + 1)}{log_2(D)} < r+2$
+       since log_2 is strictly increasing and because an array index starts at 0 (r:=r-1)
+       $r = log_2((Base - 1) * index + 1) / log_2(Base)$
+       which is slower than the above iterative method for indexes up to 10^10.
+    */
+};
+
+template<typename IntType>
+struct tree_depth<2, IntType>
+{
+    IntType operator () (IntType index) const
+    {
+        return ::boost::heap::log2(index + 1);
+    }
+};
+
+template<typename T, typename BoundArgs>
+struct select_minmax_heap
+{
+    static const bool is_mutable = extract_mutable<BoundArgs>::value;
+
+    typedef typename mpl::if_c<is_mutable,
+                               priority_queue_mutable_wrapper<min_max_heap<T, BoundArgs, nop_index_updater> >,
+                               min_max_heap<T, BoundArgs, nop_index_updater>
+                               >::type type;
+};
+
+} /* namespace detail */
+
+/**
+ * \class min_max_heap
+ * \brief min-max heap class
+ *
+ * This class implements an immutable priority queue. Internally, the min-max heap is representated
+ * as a dynamically sized array (std::vector), that directly stores the values.
+ *
+ * The template parameter T is the type to be managed by the container.
+ * The user can specify additional options and if no options are provided default options are used.
+ *
+ * The container supports the following options:
+ * - \c boost::heap::arity<>, defaults to \c arity<2>
+ * - \c boost::heap::compare<>, defaults to \c compare<std::less<T> >
+ * - \c boost::heap::stable<>, defaults to \c stable<false>
+ * - \c boost::heap::stability_counter_type<>, defaults to \c stability_counter_type<boost::uintmax_t>
+ * - \c boost::heap::allocator<>, defaults to \c allocator<std::allocator<T> >
+ * - \c boost::heap::mutable_<>, defaults to \c mutable_<false>
+ */
+#ifdef BOOST_DOXYGEN_INVOKED
+template<class T, class ...Options>
+#else
+template<typename T,
+         class A0 = boost::parameter::void_,
+         class A1 = boost::parameter::void_,
+         class A2 = boost::parameter::void_,
+         class A3 = boost::parameter::void_,
+         class A4 = boost::parameter::void_,
+         class A5 = boost::parameter::void_
+         >
+#endif
+class min_max_heap:
+    public detail::select_minmax_heap<T, typename detail::min_max_heap_signature::bind<A0, A1, A2, A3, A4, A5>::type>::type
+{
+typedef typename detail::min_max_heap_signature::bind<A0, A1, A2, A3, A4, A5>::type bound_args;
+    typedef typename detail::select_minmax_heap<T, bound_args>::type super_t;
+
+    template <typename Heap1, typename Heap2>
+    friend struct heap_merge_emulate;
+
+#ifndef BOOST_DOXYGEN_INVOKED
+    static const bool is_mutable = detail::extract_mutable<bound_args>::value;
+
+#define BOOST_HEAP_TYPEDEF_FROM_SUPER_T(NAME)   \
+    typedef typename super_t::NAME NAME;
+
+    struct implementation_defined
+    {
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(size_type)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(difference_type)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(value_compare)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(allocator_type)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(reference)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(const_reference)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(pointer)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(const_pointer)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(iterator)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(const_iterator)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(ordered_iterator)
+        BOOST_HEAP_TYPEDEF_FROM_SUPER_T(handle_type)
+    };
+#undef BOOST_HEAP_TYPEDEF_FROM_SUPER_T
+
+#endif
+public:
+    static const bool constant_time_size = true;
+    static const bool has_ordered_iterators = true;
+    static const bool is_mergable = false;
+    static const bool has_reserve = true;
+    static const bool is_stable = super_t::is_stable;
+
+    typedef T value_type;
+    typedef typename implementation_defined::size_type size_type;
+    typedef typename implementation_defined::difference_type difference_type;
+    typedef typename implementation_defined::value_compare value_compare;
+    typedef typename implementation_defined::allocator_type allocator_type;
+    typedef typename implementation_defined::reference reference;
+    typedef typename implementation_defined::const_reference const_reference;
+    typedef typename implementation_defined::pointer pointer;
+    typedef typename implementation_defined::const_pointer const_pointer;
+    /// \copydoc boost::heap::priority_queue::iterator
+    typedef typename implementation_defined::iterator iterator;
+    typedef typename implementation_defined::const_iterator const_iterator;
+    typedef typename implementation_defined::ordered_iterator ordered_iterator;
+    typedef typename implementation_defined::handle_type handle_type;
+
+public:
+    /// \copydoc boost::heap::priority_queue::priority_queue(value_compare const &)
+    explicit min_max_heap(value_compare const & cmp = value_compare()):
+        super_t(cmp)
+    {}
+
+    /// \copydoc boost::heap::priority_queue::priority_queue(priority_queue const &)
+    min_max_heap(min_max_heap const & rhs):
+        super_t(rhs)
+    {}
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+    /// \copydoc boost::heap::priority_queue::priority_queue(priority_queue &&)
+    min_max_heap(min_max_heap && rhs):
+        super_t(std::move(rhs))
+    {}
+
+    /// \copydoc boost::heap::priority_queue::operator=(priority_queue &&)
+    min_max_heap & operator=(min_max_heap && rhs)
+    {
+        super_t::operator=(std::move(rhs));
+        return *this;
+    }
+#endif
+
+    /// \copydoc boost::heap::priority_queue::operator=(priority_queue const &)
+    min_max_heap & operator=(min_max_heap const & rhs)
+    {
+        super_t::operator=(rhs);
+        return *this;
+    }
+
+public:
+    /// \copydoc boost::heap::priority_queue::empty
+    bool empty(void) const
+    {
+        return super_t::empty();
+    }
+
+    /// \copydoc boost::heap::priority_queue::size
+    size_type size(void) const
+    {
+        return super_t::size();
+    }
+
+    /// \copydoc boost::heap::priority_queue::max_size
+    size_type max_size(void) const
+    {
+        return super_t::max_size();
+    }
+
+    /// \copydoc boost::heap::priority_queue::clear
+    void clear(void)
+    {
+        super_t::clear();
+    }
+
+public:
+    /// \copydoc boost::heap::priority_queue::get_allocator
+    allocator_type get_allocator(void) const
+    {
+        return super_t::get_allocator();
+    }
+
+public:
+    /// \copydoc boost::heap::priority_queue::top
+    value_type const & top(void) const
+    {
+        return super_t::min();
+    }
+
+    /**
+     * \b Effects: Returns a const_reference to the minimum element.
+     *
+     * \b Complexity:
+     *
+     * */
+    value_type const & min(void) const
+    {
+      return super_t::min();
+    }
+
+    /**
+     * \b Effects: Returns a const_reference to the maximum element.
+     *
+     * \b Complexity:
+     *
+     * */
+    value_type const & max(void) const
+    {
+      return super_t::max();
+    }
+
+    /// \copydoc boost::heap::priority_queue::push
+    typename boost::conditional<is_mutable, handle_type, void>::type push(value_type const & v)
+    {
+        return super_t::push(v);
+    }
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+    /// \copydoc boost::heap::priority_queue::emplace
+    template <class... Args>
+    typename boost::conditional<is_mutable, handle_type, void>::type emplace(Args&&... args)
+    {
+        return super_t::emplace(std::forward<Args>(args)...);
+    }
+#endif
+
+    /// \copydoc boost::heap::priority_queue::operator<(HeapType const & rhs) const
+    template <typename HeapType>
+    bool operator<(HeapType const & rhs) const
+    {
+        return detail::heap_compare(*this, rhs);
+    }
+
+    /// \copydoc boost::heap::priority_queue::operator>(HeapType const & rhs) const
+    template <typename HeapType>
+    bool operator>(HeapType const & rhs) const
+    {
+        return detail::heap_compare(rhs, *this);
+    }
+
+    /// \copydoc boost::heap::priority_queue::operator>=(HeapType const & rhs) const
+    template <typename HeapType>
+    bool operator>=(HeapType const & rhs) const
+    {
+        return !operator<(rhs);
+    }
+
+    /// \copydoc boost::heap::priority_queue::operator<=(HeapType const & rhs) const
+    template <typename HeapType>
+    bool operator<=(HeapType const & rhs) const
+    {
+        return !operator>(rhs);
+    }
+
+    /// \copydoc boost::heap::priority_queue::operator==(HeapType const & rhs) const
+    template <typename HeapType>
+    bool operator==(HeapType const & rhs) const
+    {
+        return detail::heap_equality(*this, rhs);
+    }
+
+    /// \copydoc boost::heap::priority_queue::operator!=(HeapType const & rhs) const
+    template <typename HeapType>
+    bool operator!=(HeapType const & rhs) const
+    {
+        return !(*this == rhs);
+    }
+
+    /**
+     * \b Effects: Assigns \c v to the element handled by \c handle & updates the priority queue.
+     *
+     * \b Complexity: Logarithmic.
+     *
+     * \b Requirement: data structure must be configured as mutable
+     * */
+    void update(handle_type handle, const_reference v)
+    {
+        BOOST_STATIC_ASSERT(is_mutable);
+        super_t::update(handle, v);
+    }
+
+    /**
+     * \b Effects: Updates the heap after the element handled by \c handle has been changed.
+     *
+     * \b Complexity: Logarithmic.
+     *
+     * \b Note: If this is not called, after a handle has been updated, the behavior of the data structure is undefined!
+     *
+     * \b Requirement: data structure must be configured as mutable
+     * */
+    void update(handle_type handle)
+    {
+        BOOST_STATIC_ASSERT(is_mutable);
+        super_t::update(handle);
+    }
+
+     /**
+     * \b Effects: Assigns \c v to the element handled by \c handle & updates the priority queue.
+     *
+     * \b Complexity: Logarithmic.
+     *
+     * \b Note: The new value is expected to be greater than the current one
+     *
+     * \b Requirement: data structure must be configured as mutable
+     * */
+    void increase(handle_type handle, const_reference v)
+    {
+        BOOST_STATIC_ASSERT(is_mutable);
+        super_t::increase(handle, v);
+    }
+
+    /**
+     * \b Effects: Updates the heap after the element handled by \c handle has been changed.
+     *
+     * \b Complexity: Logarithmic.
+     *
+     * \b Note: The new value is expected to be greater than the current one. If this is not called, after a handle has been updated, the behavior of the data structure is undefined!
+     *
+     * \b Requirement: data structure must be configured as mutable
+     * */
+    void increase(handle_type handle)
+    {
+        BOOST_STATIC_ASSERT(is_mutable);
+        super_t::increase(handle);
+    }
+
+     /**
+     * \b Effects: Assigns \c v to the element handled by \c handle & updates the priority queue.
+     *
+     * \b Complexity: Logarithmic.
+     *
+     * \b Note: The new value is expected to be less than the current one
+     *
+     * \b Requirement: data structure must be configured as mutable
+     * */
+    void decrease(handle_type handle, const_reference v)
+    {
+        BOOST_STATIC_ASSERT(is_mutable);
+        super_t::decrease(handle, v);
+    }
+
+    /**
+     * \b Effects: Updates the heap after the element handled by \c handle has been changed.
+     *
+     * \b Complexity: Logarithmic.
+     *
+     * \b Note: The new value is expected to be less than the current one. If this is not called, after a handle has been updated, the behavior of the data structure is undefined!
+     *
+     * \b Requirement: data structure must be configured as mutable
+     * */
+    void decrease(handle_type handle)
+    {
+        BOOST_STATIC_ASSERT(is_mutable);
+        super_t::decrease(handle);
+    }
+
+    /**
+     * \b Effects: Removes the element handled by \c handle from the priority_queue.
+     *
+     * \b Complexity: Logarithmic.
+     *
+     * \b Requirement: data structure must be configured as mutable
+     * */
+    void erase(handle_type handle)
+    {
+        BOOST_STATIC_ASSERT(is_mutable);
+        super_t::erase(handle);
+    }
+
+    /**
+     * \b Effects: Casts an iterator to a node handle.
+     *
+     * \b Complexity: Constant.
+     *
+     * \b Requirement: data structure must be configured as mutable
+     * */
+    static handle_type s_handle_from_iterator(iterator const & it)
+    {
+        BOOST_STATIC_ASSERT(is_mutable);
+        return super_t::s_handle_from_iterator(it);
+    }
+
+    /// \copydoc boost::heap::priority_queue::pop
+    void pop(void)
+    {
+        super_t::pop_min();
+    }
+
+    /**
+     * \b Effects: Removes the element with the highest priority from the priority queue.
+     *
+     * \b Complexity:
+     *
+     * \b Note: Same as pop
+     * */
+    void pop_min(void)
+    {
+      super_t::pop_min();
+    }
+
+    /**
+     * \b Effects: Removes the element with the lowest priority from the priority queue.
+     *
+     * \b Complexity:
+     *
+     * */
+    void pop_max(void)
+    {
+      super_t::pop_max();
+    }
+
+    /// \copydoc boost::heap::priority_queue::swap
+    void swap(min_max_heap & rhs)
+    {
+        super_t::swap(rhs);
+    }
+
+    /// \copydoc boost::heap::priority_queue::begin
+    const_iterator begin(void) const
+    {
+        return super_t::begin();
+    }
+
+    /// \copydoc boost::heap::priority_queue::begin
+    iterator begin(void)
+    {
+        return super_t::begin();
+    }
+
+    /// \copydoc boost::heap::priority_queue::end
+    iterator end(void)
+    {
+        return super_t::end();
+    }
+
+    /// \copydoc boost::heap::priority_queue::end
+    const_iterator end(void) const
+    {
+        return super_t::end();
+    }
+
+    /// \copydoc boost::heap::fibonacci_heap::ordered_begin
+    ordered_iterator ordered_begin(void) const
+    {
+        return super_t::ordered_begin();
+    }
+
+    /// \copydoc boost::heap::fibonacci_heap::ordered_end
+    ordered_iterator ordered_end(void) const
+    {
+        return super_t::ordered_end();
+    }
+
+    /// \copydoc boost::heap::priority_queue::reserve
+    void reserve (size_type element_count)
+    {
+        super_t::reserve(element_count);
+    }
+
+    /// \copydoc boost::heap::priority_queue::value_comp
+    value_compare const & value_comp(void) const
+    {
+        return super_t::value_comp();
+    }
+};
+
+} /* namespace heap */
+} /* namespace boost */
+
+#undef BOOST_HEAP_ASSERT
+
+#endif /* BOOST_HEAP_MIN_MAX_HEAP_HPP */

--- a/include/boost/heap/min_max_heap.hpp
+++ b/include/boost/heap/min_max_heap.hpp
@@ -322,12 +322,12 @@ public:
 
         const std::pair<size_type, size_type> grandchildren = this->grandchildren(index);
 
-        size_type best_child = children.first;
+        size_type best = children.first;
 
-        best_between<Regular>(best_child, children.first + 1, children.second);
-        is_grandchild = best_between<Regular>(best_child, grandchildren.first, grandchildren.second);
+        best_between<Regular>(best, children.first + 1, children.second);
+        is_grandchild = best_between<Regular>(best, grandchildren.first, grandchildren.second);
 
-        return best_child;
+        return best;
     }
     /* indexes */
 
@@ -359,9 +359,8 @@ public:
                     trickle_down_impl<Regular>(m);
                 }
             }
-            else
-                if (compare<Regular>(m, i))
-                    swap(i, m);
+            else if (compare<Regular>(m, i))
+		swap(i, m);
         }
     }
 
@@ -393,8 +392,7 @@ public:
     {
         size_type grandparent = this->grandparent(i);
 
-        if(grandparent != npos()
-           && compare<Regular>(i, grandparent)) {
+        if (grandparent != npos() && compare<Regular>(i, grandparent)) {
             swap(i, grandparent);
             bubble_up_impl_<Regular>(grandparent);
         }
@@ -591,7 +589,8 @@ public:
              * The second part consists of odd levels and is a bit more complicated
              * to explore. The search has to go back up in the tree from the leaves
              * but since a node on an odd level is being pointed to by D^2 grandchildren
-             * it cannot be visited until all of its heirs have been visited.
+             * in the Hasse diagram, it cannot be visited until all of its heirs have
+	     * previously been visited.
              *
              * The 'min_max_ordered_iterator_status' structure is used to keep track
              * of this. It indicates for each node on an odd level whether its heirs
@@ -601,7 +600,7 @@ public:
              * reused to indicate to its own grandfather that it has been visited while
              * its siblings may not have yet been visited.
              *
-             * This method requires $O(log_D((D - 1) * (size() - 1) + 1))$ bytes.
+             * This method requires $O(\frac{(D - 1) * (size() - 1) + 1}{D})$ bytes.
              *
              * The following specific cases must be addressed (D = 3):
              *         0        1) when 0 is visited, it must add nodes 4-8 to the list
@@ -611,8 +610,8 @@ public:
              *     /   |   \       larger tree where the example would be a subtree.
              *    /    |    \   2) when 8 is visited, it must set its indicator and
              *   1     2     3     set the indicator for the non existing node 9 (in
-             *  /|\   /|           general for all its right siblings) and then add 2
-             * 4 5 6 7 8           if 7 has already been visited.
+             *  /|\   /|           general for all its right non existing siblings) and
+             * 4 5 6 7 8           then add 2 if 7 has already been visited.
             */
             const size_type last = heap->last();
             const bool on_compare_level = !(Forward ^ heap->is_on_compare_level(index));
@@ -1039,7 +1038,7 @@ struct select_minmax_heap
  * \class min_max_heap
  * \brief min-max heap class
  *
- * This class implements an immutable priority queue. Internally, the min-max heap is representated
+ * This class implements an double-ended priority queue. Internally, the min-max heap is represented
  * as a dynamically sized array (std::vector), that directly stores the values.
  *
  * The template parameter T is the type to be managed by the container.
@@ -1194,9 +1193,9 @@ public:
     }
 
     /**
-     * \b Effects: Returns a const_reference to the minimum element.
+     * \b Effects: Returns a const_reference to the min element.
      *
-     * \b Complexity:
+     * \b Complexity: Constant.
      *
      * */
     value_type const & min(void) const
@@ -1205,9 +1204,9 @@ public:
     }
 
     /**
-     * \b Effects: Returns a const_reference to the maximum element.
+     * \b Effects: Returns a const_reference to the max element.
      *
-     * \b Complexity:
+     * \b Complexity: Constant.
      *
      * */
     value_type const & max(void) const
@@ -1395,7 +1394,7 @@ public:
     /**
      * \b Effects: Removes the element with the highest priority from the priority queue.
      *
-     * \b Complexity:
+     * \b Complexity: Logarithmic.
      *
      * \b Note: Same as pop
      * */
@@ -1407,7 +1406,7 @@ public:
     /**
      * \b Effects: Removes the element with the lowest priority from the priority queue.
      *
-     * \b Complexity:
+     * \b Complexity: Logarithmic.
      *
      * */
     void pop_max(void)

--- a/include/boost/heap/min_max_heap.hpp
+++ b/include/boost/heap/min_max_heap.hpp
@@ -766,7 +766,7 @@ public:
 
     reverse_ordered_iterator reverse_ordered_end(void) const
     {
-        return reverse_ordered_iterator(size(), this, reverse_internal_compare(super_t::get_internal_cmp()), reverse_ordered_iterator_dispatcher(root()));
+        return reverse_ordered_iterator(size(), this, reverse_internal_compare(super_t::get_internal_cmp()), reverse_ordered_iterator_dispatcher(0));
     }
     /* iterators */
 };

--- a/test/common_heap_tests.hpp
+++ b/test/common_heap_tests.hpp
@@ -303,6 +303,32 @@ void pri_queue_test_ordered_iterators(void)
     }
 }
 
+template <typename pri_queue>
+void pri_queue_test_reverse_ordered_iterators(void)
+{
+    for (int i = 6; i != test_size; ++i) {
+        test_data data = make_test_data(i);
+        test_data shuffled (data);
+        random_shuffle(shuffled.begin(), shuffled.end());
+        pri_queue q;
+        BOOST_REQUIRE(q.reverse_ordered_begin() == q.reverse_ordered_end());
+        fill_q(q, shuffled);
+
+        test_data data_from_queue(q.reverse_ordered_begin(), q.reverse_ordered_end());
+        BOOST_REQUIRE(data == data_from_queue);
+
+        for (unsigned long j = 0; j != data.size(); ++j)
+            BOOST_REQUIRE(std::find(q.reverse_ordered_begin(), q.reverse_ordered_end(), data[j]) != q.reverse_ordered_end());
+
+        for (unsigned long j = 0; j != data.size(); ++j)
+            BOOST_REQUIRE(std::find(q.reverse_ordered_begin(), q.reverse_ordered_end(), data[j] + data.size()) == q.reverse_ordered_end());
+
+        for (unsigned long j = 0; j != data.size(); ++j) {
+            BOOST_REQUIRE_EQUAL((long)std::distance(q.begin(), q.end()), (long)(data.size() - j));
+            q.pop();
+        }
+    }
+}
 
 template <typename pri_queue>
 void pri_queue_test_equality(void)

--- a/test/common_heap_tests.hpp
+++ b/test/common_heap_tests.hpp
@@ -30,14 +30,14 @@ void random_shuffle(RandomIt first, RandomIt last)
     for (difference_type i = n-1; i > 0; --i) {
         difference_type j = std::rand() % (i + 1);
         if (j != i) {
-		   using std::swap;  
+                   using std::swap;
            swap(first[i], first[j]);
         }
     }
 }
 
 #else
-	
+
 using std::random_shuffle;
 
 #endif

--- a/test/min_max_heap_test.cpp
+++ b/test/min_max_heap_test.cpp
@@ -438,8 +438,8 @@ BOOST_AUTO_TEST_CASE( min_max_heap_mutable_stable_test )
 BOOST_AUTO_TEST_CASE( min_max_heap_compare_lookup_test )
 {
     typedef boost::heap::min_max_heap<int, boost::heap::arity<2>,
-				      boost::heap::compare<less_with_T>,
-				      boost::heap::allocator<std::allocator<int> > > pri_queue;
+                                      boost::heap::compare<less_with_T>,
+                                      boost::heap::allocator<std::allocator<int> > > pri_queue;
     run_common_heap_tests<pri_queue>();
 }
 
@@ -448,3 +448,4 @@ BOOST_AUTO_TEST_CASE( min_max_heap_leak_test )
     typedef boost::heap::min_max_heap<boost::shared_ptr<int>, boost::heap::arity<2> > pri_queue;
     run_leak_check_test<pri_queue>();
 }
+

--- a/test/min_max_heap_test.cpp
+++ b/test/min_max_heap_test.cpp
@@ -1,0 +1,110 @@
+// boost heap: min-max heap
+//
+// Copyright (C) 2019 Grégoire Scano
+//
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+#include <boost/heap/min_max_heap.hpp>
+
+#include "common_heap_tests.hpp"
+#include "stable_heap_tests.hpp"
+#include "mutable_heap_tests.hpp"
+#include "merge_heap_tests.hpp"
+
+template<unsigned int D>
+void run_tree_depth_test(void)
+{
+    boost::heap::detail::tree_depth<D, unsigned int> depth;
+
+    BOOST_REQUIRE(depth(0) == 0);
+
+    unsigned int index = 1;
+    for (unsigned int i = 1, count = D; i < 32/D; ++i, count *= D) {
+        for (unsigned int j = 0; j < count; ++j, ++index) {
+            BOOST_REQUIRE(depth(index) == i);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE( tree_depth_test )
+{
+  BOOST_REQUIRE(boost::heap::log2<unsigned long>(1) == 0);
+  BOOST_REQUIRE(boost::heap::log2<unsigned long>(2) == 1);
+
+  run_tree_depth_test<1>();
+  run_tree_depth_test<2>();
+  run_tree_depth_test<3>();
+  run_tree_depth_test<4>();
+  run_tree_depth_test<5>();
+}
+
+BOOST_AUTO_TEST_CASE( min_max_heap_paper_test )
+{
+    //int buffer[] = {5, 65, 80, 25, 37, 8, 15, 57, 36, 45, 59, 20, 14, 32, 18, 28, 30, 34, 27, 39, 38, 45, 50, 15, 12, 13, 10, 30, 31, 16, 17};
+
+    typedef boost::heap::min_max_heap<int,
+                                      boost::heap::arity<2>,
+                                      boost::heap::stable<false>,
+                                      boost::heap::compare<std::less<int> >,
+                                      boost::heap::allocator<std::allocator<int> > > pri_queue;
+
+    pri_queue q;
+
+    q.push(31);
+    q.push(17);
+    q.push(24);
+    q.push(25);
+    q.push(37);
+    q.push(8);
+    q.push(5);
+}
+
+template<int D, bool stable>
+void run_min_max_heap_test(void)
+{
+    typedef boost::heap::min_max_heap<int,
+                                      boost::heap::arity<D>,
+                                      boost::heap::stable<stable>,
+                                      boost::heap::compare<std::less<int> >,
+                                      boost::heap::allocator<std::allocator<int> > > pri_queue;
+
+    BOOST_CONCEPT_ASSERT((boost::heap::PriorityQueue<pri_queue>));
+
+    run_concept_check<pri_queue>();
+    run_common_heap_tests<pri_queue>();
+
+    run_iterator_heap_tests<pri_queue>();
+    run_copyable_heap_tests<pri_queue>();
+    run_moveable_heap_tests<pri_queue>();
+    run_reserve_heap_tests<pri_queue>();
+    run_merge_tests<pri_queue>();
+
+    //run_ordered_iterator_tests<pri_queue>();
+#if 0
+    if (stable) {
+        typedef boost::heap::min_max_heap<q_tester, boost::heap::arity<D>,
+                                          boost::heap::stable<stable>
+                                          > stable_pri_queue;
+
+        run_stable_heap_tests<stable_pri_queue>();
+    }
+#endif
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+    cmpthings ord;
+    boost::heap::min_max_heap<thing, boost::heap::arity<D>, boost::heap::compare<cmpthings>, boost::heap::stable<stable> > vpq(ord);
+    vpq.emplace(5, 6, 7);
+#endif
+}
+
+BOOST_AUTO_TEST_CASE( min_max_heap_test )
+{
+    run_min_max_heap_test<2, false>();
+    run_min_max_heap_test<3, false>();
+    run_min_max_heap_test<4, false>();
+    run_min_max_heap_test<5, false>();
+}

--- a/test/min_max_heap_test.cpp
+++ b/test/min_max_heap_test.cpp
@@ -7,6 +7,9 @@
 // http://www.boost.org/LICENSE_1_0.txt)
 
 #define BOOST_TEST_MAIN
+
+#define BOOST_HEAP_SANITYCHECKS
+
 #include <boost/test/unit_test.hpp>
 
 #include <boost/heap/min_max_heap.hpp>
@@ -15,6 +18,10 @@
 #include "stable_heap_tests.hpp"
 #include "mutable_heap_tests.hpp"
 #include "merge_heap_tests.hpp"
+
+#include <bitset>
+#include <set>
+#include <cmath>
 
 template<unsigned int D>
 void run_tree_depth_test(void)
@@ -41,6 +48,178 @@ BOOST_AUTO_TEST_CASE( tree_depth_test )
   run_tree_depth_test<3>();
   run_tree_depth_test<4>();
   run_tree_depth_test<5>();
+}
+
+void print(const std::vector<uint8_t> & v)
+{
+    for (std::vector<uint8_t>::const_iterator it = v.begin(); it != v.end(); ++it) {
+        std::cerr << std::bitset<8>(*it) << " ";
+    }
+    std::cerr << std::endl;
+}
+
+unsigned int last_line_index(unsigned int base, unsigned int max, unsigned int & depth)
+{
+    depth = 0;
+    unsigned int first = 0;
+    unsigned int local = 1;
+    unsigned int count = 1;
+    while (count <= max) {
+        first = count;
+        local *= base;
+        count += local;
+        ++depth;
+    }
+
+    return first;
+}
+
+void masks(unsigned int base, unsigned int max, unsigned int index, std::set<unsigned int> & mask, std::set<unsigned int> & umask)
+{
+    BOOST_REQUIRE(max != 0);
+
+    unsigned int depth;
+    const unsigned int last_line_left_index = last_line_index(base, max, depth);
+    mask.clear();
+
+    std::queue<unsigned int> queue;
+    queue.push(index);
+
+    while (!queue.empty()) {
+        const unsigned int child = queue.front();
+        queue.pop();
+
+        if (last_line_left_index <= child)
+            mask.insert(child);
+        else {
+            unsigned int current = base * child + 1;
+            const unsigned int right = base * (child + 1);
+
+            while (current <= right) {
+                if (current <= max)
+                    queue.push(current);
+                else
+                    mask.insert(current);
+
+                ++current;
+            }
+        }
+    }
+
+    umask.clear();
+
+    const unsigned int last_line_right_index = last_line_left_index + std::pow(base, depth) - 1;
+
+    for (unsigned int i = last_line_left_index; i <= last_line_right_index; ++i)
+        if (mask.find(i) == mask.end())
+            umask.insert(i);
+}
+
+BOOST_AUTO_TEST_CASE( run_expected_mask_test )
+{
+    std::set<unsigned int> mask;
+    std::set<unsigned int> umask;
+
+#define LOCALTEST(base, max, index, ...)                                \
+    masks(base, max, index, mask, umask);                               \
+    BOOST_REQUIRE(mask == std::set<unsigned int>(__VA_ARGS__));
+
+    LOCALTEST(2, 1, 0, {1,2});
+    LOCALTEST(2, 1, 1, {1});
+    LOCALTEST(2, 2, 0, {1,2});
+    LOCALTEST(2, 2, 1, {1});
+    LOCALTEST(2, 2, 2, {2});
+    LOCALTEST(2, 3, 0, {3,4,5,6});
+    LOCALTEST(2, 3, 1, {3,4});
+    LOCALTEST(2, 3, 2, {5,6});
+    LOCALTEST(2, 3, 3, {3});
+    LOCALTEST(2, 4, 0, {3,4,5,6});
+    LOCALTEST(2, 4, 1, {3,4});
+    LOCALTEST(2, 4, 2, {5,6});
+    LOCALTEST(2, 4, 3, {3});
+    LOCALTEST(2, 4, 4, {4});
+
+    LOCALTEST(3, 1, 0, {1,2,3});
+    LOCALTEST(3, 1, 1, {1});
+    LOCALTEST(3, 2, 0, {1,2,3});
+    LOCALTEST(3, 2, 1, {1});
+    LOCALTEST(3, 2, 2, {2});
+    LOCALTEST(3, 3, 0, {1,2,3});
+    LOCALTEST(3, 3, 1, {1});
+    LOCALTEST(3, 3, 2, {2});
+    LOCALTEST(3, 3, 3, {3});
+    LOCALTEST(3, 4, 0, {4,5,6,7,8,9,10,11,12});
+    LOCALTEST(3, 4, 1, {4,5,6});
+    LOCALTEST(3, 4, 2, {7,8,9});
+    LOCALTEST(3, 4, 3, {10,11,12});
+    LOCALTEST(3, 4, 4, {4});
+    LOCALTEST(3, 5, 0, {4,5,6,7,8,9,10,11,12});
+    LOCALTEST(3, 5, 1, {4,5,6});
+    LOCALTEST(3, 5, 2, {7,8,9});
+    LOCALTEST(3, 5, 3, {10,11,12});
+    LOCALTEST(3, 5, 4, {4});
+    LOCALTEST(3, 5, 5, {5});
+#undef LOCALTEST
+}
+
+template<unsigned int D>
+void run_min_max_ordered_iterator_status(unsigned int max)
+{
+    std::set<unsigned int> mask;
+    std::set<unsigned int> umask;
+
+    for (unsigned int max_index = 1; max_index <= std::pow(D, max) + 1; ++max_index) {
+        for (unsigned int index = 0; index <= max_index; ++index) {
+            masks(D, max_index, index, mask, umask);
+
+            {
+                boost::heap::detail::min_max_ordered_iterator_status<D, unsigned int> status(max_index);
+
+                for (std::set<unsigned int>::const_iterator it = mask.begin(); it != mask.end(); ++it) {
+                    status.set(*it);
+                    BOOST_REQUIRE(status.is_complete(*it));
+                }
+
+                BOOST_REQUIRE(status.is_complete(index));
+
+                for (std::set<unsigned int>::const_iterator it = umask.begin(); it != umask.end(); ++it)
+                    BOOST_REQUIRE(!status.is_complete(*it));
+
+                for (std::set<unsigned int>::const_iterator it = mask.begin(); it != mask.end(); ++it) {
+                    status.reset(*it);
+                    BOOST_REQUIRE(!status.is_complete(*it));
+                }
+
+                BOOST_REQUIRE(!status.is_complete(index));
+            }
+
+            {
+                boost::heap::detail::min_max_ordered_iterator_status<D, unsigned int> status(max_index);
+
+                status.set(index);
+
+                for (std::set<unsigned int>::const_iterator it = mask.begin(); it != mask.end(); ++it)
+                    BOOST_REQUIRE(status.is_complete(*it));
+
+                for (std::set<unsigned int>::const_iterator it = umask.begin(); it != umask.end(); ++it)
+                    BOOST_REQUIRE(!status.is_complete(*it));
+
+                status.reset(index);
+                BOOST_REQUIRE(!status.is_complete(index));
+
+                for (std::set<unsigned int>::const_iterator it = mask.begin(); it != mask.end(); ++it)
+                    BOOST_REQUIRE(!status.is_complete(*it));
+            }
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE( run_min_max_ordered_iterator_status_test )
+{
+    run_min_max_ordered_iterator_status<2>(7);
+    run_min_max_ordered_iterator_status<3>(3);
+    run_min_max_ordered_iterator_status<4>(2);
+    run_min_max_ordered_iterator_status<5>(2);
 }
 
 BOOST_AUTO_TEST_CASE( min_max_heap_paper_test )
@@ -76,13 +255,22 @@ void run_min_max_heap_test(void)
     BOOST_CONCEPT_ASSERT((boost::heap::PriorityQueue<pri_queue>));
 
     run_concept_check<pri_queue>();
-    run_common_heap_tests<pri_queue>();
+    //run_common_heap_tests<pri_queue>();
+    pri_queue_test_sequential_push<pri_queue>();
+    pri_queue_test_sequential_reverse_push<pri_queue>();
+    pri_queue_test_random_push<pri_queue>();
+    pri_queue_test_equality<pri_queue>();
+    pri_queue_test_inequality<pri_queue>();
+    pri_queue_test_less<pri_queue>();
+    pri_queue_test_clear<pri_queue>();
 
-    run_iterator_heap_tests<pri_queue>();
-    run_copyable_heap_tests<pri_queue>();
-    run_moveable_heap_tests<pri_queue>();
-    run_reserve_heap_tests<pri_queue>();
-    run_merge_tests<pri_queue>();
+    pri_queue_test_emplace<pri_queue>();
+    //
+    //run_iterator_heap_tests<pri_queue>();
+    //run_copyable_heap_tests<pri_queue>();
+    //run_moveable_heap_tests<pri_queue>();
+    //run_reserve_heap_tests<pri_queue>();
+    //run_merge_tests<pri_queue>();
 
     //run_ordered_iterator_tests<pri_queue>();
 #if 0
@@ -104,7 +292,7 @@ void run_min_max_heap_test(void)
 BOOST_AUTO_TEST_CASE( min_max_heap_test )
 {
     run_min_max_heap_test<2, false>();
-    run_min_max_heap_test<3, false>();
-    run_min_max_heap_test<4, false>();
-    run_min_max_heap_test<5, false>();
+    //run_min_max_heap_test<3, false>();
+    //run_min_max_heap_test<4, false>();
+    //run_min_max_heap_test<5, false>();
 }

--- a/test/min_max_heap_test.cpp
+++ b/test/min_max_heap_test.cpp
@@ -359,7 +359,6 @@ void run_min_max_heap_test(void)
     run_ordered_iterator_tests<pri_queue>();
     run_reverse_ordered_iterator_tests<pri_queue>();
 
-#if 0
     if (stable) {
         typedef boost::heap::min_max_heap<q_tester, boost::heap::arity<D>,
                                           boost::heap::stable<stable>
@@ -367,7 +366,7 @@ void run_min_max_heap_test(void)
 
         run_stable_heap_tests<stable_pri_queue>();
     }
-#endif
+
 #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
     cmpthings ord;
     boost::heap::min_max_heap<thing, boost::heap::arity<D>, boost::heap::compare<cmpthings>, boost::heap::stable<stable> > vpq(ord);
@@ -381,4 +380,12 @@ BOOST_AUTO_TEST_CASE( min_max_heap_test )
     run_min_max_heap_test<3, false>();
     run_min_max_heap_test<4, false>();
     run_min_max_heap_test<5, false>();
+}
+
+BOOST_AUTO_TEST_CASE( min_max_heap_stable_test )
+{
+    run_min_max_heap_test<2, true>();
+    run_min_max_heap_test<3, true>();
+    run_min_max_heap_test<4, true>();
+    run_min_max_heap_test<5, true>();
 }

--- a/test/min_max_heap_test.cpp
+++ b/test/min_max_heap_test.cpp
@@ -237,6 +237,12 @@ struct dispatcher_queue : boost::heap::detail::min_max_heap<T, BoundArgs, IndexU
     }
 };
 
+/*
+ * Testing the iterator dispatcher for ordered iterator only
+ * (true template parameter) because the reverse iterator
+ * dispatcher merely switches the result of is_on_compare_level
+ * while the tree examination remains the same.
+*/
 template <unsigned int D>
 void run_min_max_heap_iterator_dispatcher_upward_test()
 {
@@ -248,7 +254,7 @@ void run_min_max_heap_iterator_dispatcher_upward_test()
         boost::parameter::void_,
         boost::parameter::void_>::type signature;
     typedef dispatcher_queue<int, signature, boost::heap::detail::nop_index_updater> pri_queue;
-    typedef typename pri_queue::iterator_dispatcher iterator_dispatcher;
+    typedef typename pri_queue::template iterator_dispatcher<true> iterator_dispatcher;
 
     pri_queue q;
     std::pair<long unsigned int, long unsigned int> regular;
@@ -291,7 +297,7 @@ BOOST_AUTO_TEST_CASE( min_max_heap_iterator_dispatcher_test )
         boost::parameter::void_,
         boost::parameter::void_>::type signature;
     typedef dispatcher_queue<int, signature, boost::heap::detail::nop_index_updater> pri_queue;
-    typedef typename pri_queue::iterator_dispatcher iterator_dispatcher;
+    typedef typename pri_queue::template iterator_dispatcher<true> iterator_dispatcher;
 
     pri_queue q;
     std::pair<long unsigned int, long unsigned int> regular;
@@ -351,6 +357,8 @@ void run_min_max_heap_test(void)
     run_merge_tests<pri_queue>();
 
     run_ordered_iterator_tests<pri_queue>();
+    run_reverse_ordered_iterator_tests<pri_queue>();
+
 #if 0
     if (stable) {
         typedef boost::heap::min_max_heap<q_tester, boost::heap::arity<D>,

--- a/test/min_max_heap_test.cpp
+++ b/test/min_max_heap_test.cpp
@@ -389,3 +389,50 @@ BOOST_AUTO_TEST_CASE( min_max_heap_stable_test )
     run_min_max_heap_test<4, true>();
     run_min_max_heap_test<5, true>();
 }
+
+template <int D, bool stable>
+void run_min_max_heap_mutable_test(void)
+{
+    typedef boost::heap::min_max_heap<int, boost::heap::mutable_<true>,
+                                            boost::heap::arity<D>,
+                                            boost::heap::stable<stable>
+                                           > pri_queue;
+
+    BOOST_CONCEPT_ASSERT((boost::heap::MutablePriorityQueue<pri_queue>));
+
+    run_common_heap_tests<pri_queue>();
+    run_moveable_heap_tests<pri_queue>();
+    run_reserve_heap_tests<pri_queue>();
+    run_mutable_heap_tests<pri_queue>();
+
+    run_merge_tests<pri_queue>();
+
+    run_ordered_iterator_tests<pri_queue>();
+    run_reverse_ordered_iterator_tests<pri_queue>();
+
+    if (stable) {
+        typedef boost::heap::min_max_heap<q_tester,
+                                          boost::heap::mutable_<true>,
+                                          boost::heap::arity<D>,
+                                          boost::heap::stable<stable>
+                                          > stable_pri_queue;
+        run_stable_heap_tests<stable_pri_queue>();
+    }
+}
+
+BOOST_AUTO_TEST_CASE( min_max_heap_mutable_test )
+{
+    run_min_max_heap_mutable_test<2, false>();
+    run_min_max_heap_mutable_test<3, false>();
+    run_min_max_heap_mutable_test<4, false>();
+    run_min_max_heap_mutable_test<5, false>();
+}
+
+BOOST_AUTO_TEST_CASE( min_max_heap_mutable_stable_test )
+{
+    run_min_max_heap_mutable_test<2, true>();
+    run_min_max_heap_mutable_test<3, true>();
+    run_min_max_heap_mutable_test<4, true>();
+    run_min_max_heap_mutable_test<5, true>();
+}
+

--- a/test/min_max_heap_test.cpp
+++ b/test/min_max_heap_test.cpp
@@ -19,7 +19,6 @@
 #include "mutable_heap_tests.hpp"
 #include "merge_heap_tests.hpp"
 
-#include <bitset>
 #include <set>
 #include <cmath>
 
@@ -436,3 +435,16 @@ BOOST_AUTO_TEST_CASE( min_max_heap_mutable_stable_test )
     run_min_max_heap_mutable_test<5, true>();
 }
 
+BOOST_AUTO_TEST_CASE( min_max_heap_compare_lookup_test )
+{
+    typedef boost::heap::min_max_heap<int, boost::heap::arity<2>,
+				      boost::heap::compare<less_with_T>,
+				      boost::heap::allocator<std::allocator<int> > > pri_queue;
+    run_common_heap_tests<pri_queue>();
+}
+
+BOOST_AUTO_TEST_CASE( min_max_heap_leak_test )
+{
+    typedef boost::heap::min_max_heap<boost::shared_ptr<int>, boost::heap::arity<2> > pri_queue;
+    run_leak_check_test<pri_queue>();
+}

--- a/test/mutable_heap_tests.hpp
+++ b/test/mutable_heap_tests.hpp
@@ -323,3 +323,9 @@ void run_ordered_iterator_tests()
 {
     pri_queue_test_ordered_iterators<pri_queue>();
 }
+
+template <typename pri_queue>
+void run_reverse_ordered_iterator_tests()
+{
+    pri_queue_test_reverse_ordered_iterators<pri_queue>();
+}


### PR DESCRIPTION
This is an implementation of a min-max heap as described in the paper 'Min-Max Heaps and Generalized Priority Queue' by Atkinson et al..
Because I extended this data structure to the arity aspect, I based my work on the D-ary heap for the general structure of the class.
All regular tests as well as stability and mutability tests are integrated.

I just want to point your attention towards the modifications I made, for the sake of iterators (ordered and reverse ordered), to `mutable_heap.hpp` and `ordered_adaptor_iterator.hpp`.
Because the function `get_child_nodes` had to return more than one range of indexes (as min and max levels are intertwined within the tree) I had to design an `extended_ordered_adaptor_iterator` inheriting from `ordered_adaptor_iterator` and thus created a global `ordered_adaptor_iterator_facade` to avoid code duplication between those two. The same applies to `priority_queue_mutable_wrapper` inner structure `ordered_iterator`.