### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -5,27 +5,30 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/array//boost_array
+    /boost/assert//boost_assert
+    /boost/bind//boost_bind
+    /boost/concept_check//boost_concept_check
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/intrusive//boost_intrusive
+    /boost/iterator//boost_iterator
+    /boost/parameter//boost_parameter
+    /boost/static_assert//boost_static_assert
+    /boost/throw_exception//boost_throw_exception
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/heap
     : common-requirements
-        <library>/boost/array//boost_array
-        <library>/boost/assert//boost_assert
-        <library>/boost/bind//boost_bind
-        <library>/boost/concept_check//boost_concept_check
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/intrusive//boost_intrusive
-        <library>/boost/iterator//boost_iterator
-        <library>/boost/parameter//boost_parameter
-        <library>/boost/static_assert//boost_static_assert
-        <library>/boost/throw_exception//boost_throw_exception
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_heap ]
+    [ alias boost_heap : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_heap test ]
     ;
 
 call-if : boost-library heap
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -7,18 +7,18 @@ import project ;
 
 project /boost/heap
     : common-requirements
-        <source>/boost/array//boost_array
-        <source>/boost/assert//boost_assert
-        <source>/boost/bind//boost_bind
-        <source>/boost/concept_check//boost_concept_check
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
-        <source>/boost/intrusive//boost_intrusive
-        <source>/boost/iterator//boost_iterator
-        <source>/boost/parameter//boost_parameter
-        <source>/boost/static_assert//boost_static_assert
-        <source>/boost/throw_exception//boost_throw_exception
-        <source>/boost/type_traits//boost_type_traits
+        <library>/boost/array//boost_array
+        <library>/boost/assert//boost_assert
+        <library>/boost/bind//boost_bind
+        <library>/boost/concept_check//boost_concept_check
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
+        <library>/boost/intrusive//boost_intrusive
+        <library>/boost/iterator//boost_iterator
+        <library>/boost/parameter//boost_parameter
+        <library>/boost/static_assert//boost_static_assert
+        <library>/boost/throw_exception//boost_throw_exception
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,31 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/heap
+    : common-requirements
+        <source>/boost/array//boost_array
+        <source>/boost/assert//boost_assert
+        <source>/boost/bind//boost_bind
+        <source>/boost/concept_check//boost_concept_check
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <source>/boost/intrusive//boost_intrusive
+        <source>/boost/iterator//boost_iterator
+        <source>/boost/parameter//boost_parameter
+        <source>/boost/static_assert//boost_static_assert
+        <source>/boost/throw_exception//boost_throw_exception
+        <source>/boost/type_traits//boost_type_traits
+        <include>include
+    ;
+
+explicit
+    [ alias boost_heap ]
+    [ alias all : boost_heap test ]
+    ;
+
+call-if : boost-library heap
+    ;

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/heap

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/heap
     : common-requirements

--- a/doc/Jamfile.v2
+++ b/doc/Jamfile.v2
@@ -7,7 +7,7 @@ import quickbook ;
 
 doxygen autodoc
     :
-        [ glob ../../../boost/heap/*.hpp ] ../../../boost/heap/detail/mutable_heap.hpp
+        [ glob ../include/boost/heap/*.hpp ] ../include/boost/heap/detail/mutable_heap.hpp
     :
         #<doxygen:param>EXTRACT_ALL=YES
         <doxygen:param>"PREDEFINED=\"BOOST_DOXYGEN_INVOKED\" \\

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -6,11 +6,13 @@ import testing ;
 import path ;
 import regex ;
 
+path-constant HERE : . ;
+
 rule test_all
 {
     local all_rules ;
     local file ;
-    local headers_path = [ path.make $(BOOST_ROOT)/libs/heap/include/boost/heap ] ;
+    local headers_path = [ path.make $(HERE)/../include/boost/heap ] ;
     for file in [ path.glob-tree $(headers_path) : *.hpp : detail ]
     {
         local rel_file = [ path.relative-to $(headers_path) $(file) ] ;
@@ -29,7 +31,8 @@ rule test_all
                 :  # additional args
                 :  # test-files
                 : <library>/boost/test//boost_unit_test_framework # requirements
-                  <library>/boost/container
+                  <library>/boost/container//boost_container
+                  <library>/boost/foreach//boost_foreach
             ] ;
         }
    }

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -8,6 +8,8 @@ import regex ;
 
 path-constant HERE : . ;
 
+project : requirements <library>/boost/heap//boost_heap ;
+
 rule test_all
 {
     local all_rules ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.