### PR TITLE
Fixed compilation issue.

### DIFF
--- a/include/boost/heap/detail/mutable_heap.hpp
+++ b/include/boost/heap/detail/mutable_heap.hpp
@@ -407,7 +407,7 @@ public:
      * */
     void increase( handle_type handle, const_reference v )
     {
-        BOOST_ASSERT( !value_compare()( v, handle.iterator->first ) );
+        BOOST_ASSERT( !value_comp()( v, handle.iterator->first ) );
         handle.iterator->first = v;
         increase( handle );
     }
@@ -436,7 +436,7 @@ public:
      * */
     void decrease( handle_type handle, const_reference v )
     {
-        BOOST_ASSERT( !value_compare()( handle.iterator->first, v ) );
+        BOOST_ASSERT( !value_comp()( handle.iterator->first, v ) );
         handle.iterator->first = v;
         decrease( handle );
     }


### PR DESCRIPTION
There was a typo (value_compare() vs. value_comp()), causing compilation errors when value_compare was not default constructible and assertions were enabled.

This fixes my issue #42 .