### PR TITLE
Remove dependencies on Boost.StaticAssert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ target_link_libraries(boost_heap
     Boost::intrusive
     Boost::iterator
     Boost::parameter
-    Boost::static_assert
     Boost::throw_exception
 )
 

--- a/build.jam
+++ b/build.jam
@@ -13,7 +13,6 @@ constant boost_dependencies :
     /boost/intrusive//boost_intrusive
     /boost/iterator//boost_iterator
     /boost/parameter//boost_parameter
-    /boost/static_assert//boost_static_assert
     /boost/throw_exception//boost_throw_exception ;
 
 project /boost/heap

--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -34,7 +34,6 @@ set(deps
     predef
     preprocessor
     smart_ptr
-    static_assert
     throw_exception
     tuple
     type_traits


### PR DESCRIPTION
Boost.StaticAssert has been merged into Boost.Config, so remove the dependency.